### PR TITLE
improve consult line experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ the completion display with documentation strings.
 ### Jumping and Search
 
   * `consult-line`: Jump to a line matching the selected text. Supports live preview and recursive editing of the preview.
+  * `consult-line-symbol-at-point`: Search by `consult-line` for symbol at point.
+  * `consult-line-from-isearch`: Fast switch searching from `isearch` to `consult-line`.
   * `consult-mark`: Jump to a marker in the `mark-ring`. Supports live preview and recursive editing of the preview.
   * `consult-outline`: Jump to a heading of the outline. Supports live preview and recursive editing of the preview.
   * `consult-multi-occur`: Replacement for `multi-occur`.

--- a/consult.el
+++ b/consult.el
@@ -550,7 +550,7 @@ WIDTH is the line number width."
 (defun consult-line (&optional initial)
   "Search for a matching line and jump to the line beginning.
 The default candidate is a non-empty line closest to point.
-This command obeys narrowing. Optionaly you can provide INITIAL input."
+This command obeys narrowing. Optionally you can provide INITIAL input."
   (interactive)
   (consult--goto
    (let ((candidates (consult--gc-increase (consult--line-candidates))))
@@ -562,7 +562,7 @@ This command obeys narrowing. Optionaly you can provide INITIAL input."
                       :history 'consult-line-history
                       :lookup (lambda (candidates x) (cdr (assoc x candidates)))
                       :default (car candidates)
-		      :initial initial
+                      :initial initial
                       :preview (and consult-preview-line #'consult--preview-line))))))
 
 ;;;###autoload
@@ -575,7 +575,9 @@ This command obeys narrowing. Optionaly you can provide INITIAL input."
 (defun consult-line-from-isearch ()
   "Search by lines from isearch string."
   (interactive)
-  (consult-line isearch-string))
+  (consult-line (if isearch-regexp
+		    isearch-string
+		  (regexp-quote isearch-string))))
 
 (defun consult--recent-file-read ()
   "Read recent file via `completing-read'."

--- a/consult.el
+++ b/consult.el
@@ -547,10 +547,10 @@ WIDTH is the line number width."
     (cons default-cand (nreverse candidates))))
 
 ;;;###autoload
-(defun consult-line ()
+(defun consult-line (&optional initial)
   "Search for a matching line and jump to the line beginning.
 The default candidate is a non-empty line closest to point.
-This command obeys narrowing."
+This command obeys narrowing. Optionaly you can provide INITIAL input."
   (interactive)
   (consult--goto
    (let ((candidates (consult--gc-increase (consult--line-candidates))))
@@ -562,7 +562,20 @@ This command obeys narrowing."
                       :history 'consult-line-history
                       :lookup (lambda (candidates x) (cdr (assoc x candidates)))
                       :default (car candidates)
+		      :initial initial
                       :preview (and consult-preview-line #'consult--preview-line))))))
+
+;;;###autoload
+(defun consult-line-symbol-at-point ()
+  "Search for a symbol at point."
+  (interactive)
+  (consult-line (thing-at-point 'symbol)))
+
+;;;###autoload
+(defun consult-line-from-isearch ()
+  "Search by lines from isearch string."
+  (interactive)
+  (consult-line isearch-string))
 
 (defun consult--recent-file-read ()
   "Read recent file via `completing-read'."


### PR DESCRIPTION
Add optional arg `initial` to consult line. Implement `consult-line-symbol-at-point` & `consult-line-from-isearch`. See #16 