### PR TITLE
Create ‘consult-kmacro’.

### DIFF
--- a/consult.el
+++ b/consult.el
@@ -997,19 +997,20 @@ ones made entirely of mouse clicks) are not shown."
         ;;
         ;; Get actual index, since we prepended ‘kmacro-ring’
         ;; with ‘last-kbd-macro’ in selection.
-        (let ((actual-index (1- chosen-kmacro-index)))
-          ;; Temporarily change the variables to retrieve the correct
-          ;; settings.  Mainly, we want the macro counter to persist, which
-          ;; automatically happens when cycling the ring.
-          (cl-destructuring-bind
-              (last-kbd-macro kmacro-counter kmacro-counter-format-start)
-              (nth actual-index kmacro-ring)
-            (kmacro-call-macro (or arg 1) t)
-            ;; Once done, put updated variables back into the ring.
-            (setf (nth actual-index kmacro-ring)
-                  (list last-kbd-macro
-                        kmacro-counter
-                        kmacro-counter-format))))))))
+        (let* ((actual-index (1- chosen-kmacro-index))
+               (actual-kmacro (nth actual-index kmacro-ring))
+               ;; Temporarily change the variables to retrieve the correct
+               ;; settings.  Mainly, we want the macro counter to persist, which
+               ;; automatically happens when cycling the ring.
+               (last-kbd-macro (car actual-kmacro))
+               (kmacro-counter (cadr actual-kmacro))
+               (kmacro-counter-format (caddr actual-kmacro)))
+          (kmacro-call-macro (or arg 1) t)
+          ;; Once done, put updated variables back into the ring.
+          (setf (nth actual-index kmacro-ring)
+                (list last-kbd-macro
+                      kmacro-counter
+                      kmacro-counter-format)))))))
 
 ;;;; consult-preview-mode - Enabling preview for consult commands
 

--- a/consult.el
+++ b/consult.el
@@ -38,6 +38,7 @@
 
 (require 'bookmark)
 (require 'cl-lib)
+(require 'kmacro)
 (require 'outline)
 (require 'recentf)
 (require 'seq)
@@ -220,11 +221,6 @@ nil shows all `custom-available-themes'."
 (defvar package-archive-contents)
 (declare-function package-desc-summary "package")
 (declare-function package--from-builtin "package")
-
-(defvar kmacro-ring)
-(defvar kmacro-counter)
-(defvar kmacro-counter-format)
-(defvar kmacro-counter-format-start)
 
 ;;;; Helper functions
 

--- a/consult.el
+++ b/consult.el
@@ -948,68 +948,68 @@ Macros containing mouse clicks can't be displayed properly.  To
 keep things simple, macros with an empty display string (e.g.,
 ones made entirely of mouse clicks) are not shown."
   (interactive "p")
-  (if (or last-kbd-macro kmacro-ring)
-      (let* ((numbered-kmacros
-              (delete
-               nil
-               (seq-map-indexed
-                (lambda (kmacro index)
-                  (let ((formatted-kmacro
-                         (condition-case nil
-                             (format-kbd-macro (if (listp kmacro)
-                                                   (cl-first kmacro)
-                                                 kmacro)
-                                               1)
-                           ;; Recover from error from
-                           ;; ‘edmacro-fix-menu-commands’.  In Emacs 27, it
-                           ;; looks like mouse events are silently skipped over.
-                           (error
-                            "Warning: Cannot display macros containing mouse clicks"))))
-                    (unless (string-empty-p formatted-kmacro)
-                      (cons (concat (when (consp kmacro)
-                                      (format "%d,%s: "
-                                              (cl-second kmacro)
-                                              (cl-third kmacro)))
-                                    formatted-kmacro)
-                            index))))
-                ;; The most recent macro is not on the ring, so it must be
-                ;;  explicitly included.
-                (cons (if (listp last-kbd-macro)
-                          last-kbd-macro
-                        (list last-kbd-macro
-                              kmacro-counter
-                              kmacro-counter-format))
-                      kmacro-ring))))
-             ;; The index corresponding to the chosen kmacro.
-             (chosen-kmacro-index
-              (consult--read "Keyboard macro: "
-                             numbered-kmacros
-                             :require-match t
-                             :sort nil
-                             :history 'consult-kmacro-history
-                             :lookup (lambda (candidates x)
-                                       (cdr (assoc x candidates))))))
-        (if (= chosen-kmacro-index 0)
-            ;; If 0, just run the current (last) macro.
-            (kmacro-call-macro (or arg 1) t nil)
-          ;; Otherwise, run a kmacro from the ring.
-          ;;
-          ;; Get actual index, since we prepended ‘kmacro-ring’
-          ;; with ‘last-kbd-macro’ in selection.
-          (let ((actual-index (1- chosen-kmacro-index)))
-            ;; Temporarily change the variables to retrieve the correct
-            ;; settings.  Mainly, we want the macro counter to persist, which
-            ;; automatically happens when cycling the ring.
-            (cl-destructuring-bind
-                (last-kbd-macro kmacro-counter kmacro-counter-format-start)
-                (nth actual-index kmacro-ring)
-              (kmacro-call-macro (or arg 1) t)
-              ;; Once done, put updated variables back into the ring.
-              (setf (nth actual-index kmacro-ring)
-                    (list last-kbd-macro
-                          kmacro-counter
-                          kmacro-counter-format))))))
-    (user-error "No keyboard macros defined")))
+  (if (not (or last-kbd-macro kmacro-ring))
+      (user-error "No keyboard macros defined")
+    (let* ((numbered-kmacros
+            (delete
+             nil
+             (seq-map-indexed
+              (lambda (kmacro index)
+                (let ((formatted-kmacro
+                       (condition-case nil
+                           (format-kbd-macro (if (listp kmacro)
+                                                 (cl-first kmacro)
+                                               kmacro)
+                                             1)
+                         ;; Recover from error from
+                         ;; ‘edmacro-fix-menu-commands’.  In Emacs 27, it
+                         ;; looks like mouse events are silently skipped over.
+                         (error
+                          "Warning: Cannot display macros containing mouse clicks"))))
+                  (unless (string-empty-p formatted-kmacro)
+                    (cons (concat (when (consp kmacro)
+                                    (format "%d,%s: "
+                                            (cl-second kmacro)
+                                            (cl-third kmacro)))
+                                  formatted-kmacro)
+                          index))))
+              ;; The most recent macro is not on the ring, so it must be
+              ;;  explicitly included.
+              (cons (if (listp last-kbd-macro)
+                        last-kbd-macro
+                      (list last-kbd-macro
+                            kmacro-counter
+                            kmacro-counter-format))
+                    kmacro-ring))))
+           ;; The index corresponding to the chosen kmacro.
+           (chosen-kmacro-index
+            (consult--read "Keyboard macro: "
+                           numbered-kmacros
+                           :require-match t
+                           :sort nil
+                           :history 'consult-kmacro-history
+                           :lookup (lambda (candidates x)
+                                     (cdr (assoc x candidates))))))
+      (if (= chosen-kmacro-index 0)
+          ;; If 0, just run the current (last) macro.
+          (kmacro-call-macro (or arg 1) t nil)
+        ;; Otherwise, run a kmacro from the ring.
+        ;;
+        ;; Get actual index, since we prepended ‘kmacro-ring’
+        ;; with ‘last-kbd-macro’ in selection.
+        (let ((actual-index (1- chosen-kmacro-index)))
+          ;; Temporarily change the variables to retrieve the correct
+          ;; settings.  Mainly, we want the macro counter to persist, which
+          ;; automatically happens when cycling the ring.
+          (cl-destructuring-bind
+              (last-kbd-macro kmacro-counter kmacro-counter-format-start)
+              (nth actual-index kmacro-ring)
+            (kmacro-call-macro (or arg 1) t)
+            ;; Once done, put updated variables back into the ring.
+            (setf (nth actual-index kmacro-ring)
+                  (list last-kbd-macro
+                        kmacro-counter
+                        kmacro-counter-format))))))))
 
 ;;;; consult-preview-mode - Enabling preview for consult commands
 

--- a/consult.el
+++ b/consult.el
@@ -990,7 +990,7 @@ ones made entirely of mouse clicks) are not shown."
                            :history 'consult-kmacro-history
                            :lookup (lambda (candidates x)
                                      (cdr (assoc x candidates))))))
-      (if (= chosen-kmacro-index 0)
+      (if (zerop chosen-kmacro-index)
           ;; If 0, just run the current (last) macro.
           (kmacro-call-macro (or arg 1) t nil)
         ;; Otherwise, run a kmacro from the ring.

--- a/consult.el
+++ b/consult.el
@@ -951,8 +951,8 @@ ones made entirely of mouse clicks) are not shown."
   (if (not (or last-kbd-macro kmacro-ring))
       (user-error "No keyboard macros defined")
     (let* ((numbered-kmacros
-            (delete
-             nil
+            (seq-remove
+             (lambda (x) (equal " " (car x)))
              (seq-map-indexed
               (lambda (kmacro index)
                 (let ((formatted-kmacro
@@ -966,13 +966,14 @@ ones made entirely of mouse clicks) are not shown."
                          ;; looks like mouse events are silently skipped over.
                          (error
                           "Warning: Cannot display macros containing mouse clicks"))))
-                  (unless (string-empty-p formatted-kmacro)
-                    (cons (concat (when (consp kmacro)
-                                    (format "%d,%s: "
-                                            (cl-second kmacro)
-                                            (cl-third kmacro)))
-                                  formatted-kmacro)
-                          index))))
+                  (cons (concat (when (consp kmacro)
+                                  (propertize " "
+                                              'display
+                                              (format "%d,%s: "
+                                                      (cl-second kmacro)
+                                                      (cl-third kmacro))))
+                                formatted-kmacro)
+                        index)))
               ;; The most recent macro is not on the ring, so it must be
               ;;  explicitly included.
               (cons (if (listp last-kbd-macro)


### PR DESCRIPTION
This is basically the same as the `selectrum-kmacro` version.

Consistent with `consult-register`, information about the keyboard macro is part of the candidate instead of being prefixed via the `selectrum-candidate-display-prefix` property. This makes history less useful for candidates containing counters, as the recorded candidate will no longer be correct after running the macro again.

Do you have a preferred method for dealing with such issues?