### PR TITLE
Only add counter information when kmacro would insert counter.

### DIFF
--- a/consult.el
+++ b/consult.el
@@ -935,9 +935,16 @@ Depending on the selected item OPEN-BUFFER, OPEN-FILE or OPEN-BOOKMARK will be u
      (mapcar (pcase-lambda (`((,keys ,counter ,format) . ,index))
                (cons
                 (concat
-                 (propertize " "
-                             'display
-                             (format "%d(%s) " counter format))
+                 ;; If the counter is 0 and the counter format is its default,
+                 ;; then there is a good chance that the counter isn't actually
+                 ;; being used.  This can only be wrong when a user
+                 ;; intentionally starts the counter with a negative value and
+                 ;; then increments it to 0.
+                 (unless (and (eql counter 0)
+                              (string= format "%d"))
+                   (propertize " "
+                               'display
+                               (format "%d(%s) " counter format)))
                  (format-kbd-macro keys 1))
                 index))))
    ;; Remove duplicates


### PR DESCRIPTION
This uses `where-is-internal` to find the keybindings of `kmacro-insert-counter` and `kmacro-start-macro-or-insert-counter`.

In testing it, it only adds the counter information when that macro would insert the counter. For example, if I locally bind `kmacro-insert-counter` to `C-c i`, then `consult-kmacro` will treat that key sequence as inserting the counter in that particular buffer, but not others. It also works similarly for Evil bindings.

Does this work for you?

EDIT:

It seems to only check against the current Evil state, so it might be not be correct if the kmacro changes the Evil state. But, I think it would be odd to define a macro in one state and then try to use it a different Evil state. I think it is more likely that Evil users would just use Evil macros.