### PR TITLE
Have the consult-yank* commands report the category 'kill-ring

### DIFF
--- a/consult.el
+++ b/consult.el
@@ -654,6 +654,7 @@ The arguments and expected return value are as specified for
   "Open kill ring menu and return selected text."
   (consult--read "Ring: "
                  (delete-dups (seq-copy kill-ring))
+                 :category 'kill-ring
                  :require-match t))
 
 ;; Insert selected text.


### PR DESCRIPTION
I'd find it useful for the yank commands to some special category so I can configure embark to display them vertically instead of in a grid view. But even without that selfish motivation, it's probably a good idea to have them report some category.

I choose the name `kill-ring` for the category, but maybe you have a better suggestion.