### PR TITLE
Add a horizontal line below each consult--yank-read candidate

### DIFF
--- a/consult.el
+++ b/consult.el
@@ -653,7 +653,12 @@ The arguments and expected return value are as specified for
 (defun consult--yank-read ()
   "Open kill ring menu and return selected text."
   (consult--read "Ring: "
-                 (delete-dups (seq-copy kill-ring))
+                 (let* ((sep (propertize
+                              (concat "\n" (make-string (1- (window-width)) ?—))
+                              'face 'shadow)))
+                   (mapcar (lambda (str)
+                             (propertize str 'display (concat str sep)))
+                           (delete-dups kill-ring)))
                  :require-match t))
 
 ;; Insert selected text.


### PR DESCRIPTION
- The candidates do not include the horizontal line, it is only
displayed via text properties.

- The line comes at the end of the candidate, so I believe this should
not affect what selectrum displays at all. (This should be tested.)
So, this doesn't improve things for selectrum, but it should keep them
the same.

- Both icomplete-vertical and embark-occur display the full multiline
candidate. So consult + either can be regarded as a substitute for
browse-kill-ring. (We mentioned embark-occur already, I forgot that
icomplete-vertical shows multiline candidates too.)