### PR TITLE
replace consult-minibuffer-history by consult-history

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,9 @@ information (e.g. `M-x`, `describe-face`, `describe-symbol`, `helpful-function`,
 ### Histories
 
   * `consult-command-history`: Select a command from the `command-history`.
-  * `consult-minibuffer-history`: Insert a string from the `minibuffer-history`.
+  * `consult-history`: Insert a string from the current buffer history.
+    This command can be invoked from the minibuffer. In that case the history
+    stored in the minibuffer-history-variable is used.
 
 ### Jumping and Search
 
@@ -127,7 +129,8 @@ order to use the enhanced commands, you must configure the keybindings yourself.
 ;; Example configuration for Consult
 (use-package consult
   ;; Replace bindings. Lazily loaded due to use-package.
-  :bind (("C-c o" . consult-outline)
+  :bind (("C-c h" . consult-history)
+         ("C-c o" . consult-outline)
          ("C-x b" . consult-buffer)
          ("C-x 4 b" . consult-buffer-other-window)
          ("C-x 5 b" . consult-buffer-other-frame)
@@ -167,14 +170,14 @@ order to use the enhanced commands, you must configure the keybindings yourself.
 
 | Variable                   | Def | Description                                             |
 |----------------------------|-----|---------------------------------------------------------|
-| consult-annotate-alist     | …   | Functions which should get a richer completion display. |
 | consult-line-numbers-widen | t   | Show absolute line numbers when narrowing is active.    |
+| consult-mode-histories     | …   | Mode-specific history variables                         |
 | consult-preview-buffer     | t   | Enable buffer preview during selection                  |
-| consult-preview-theme      | t   | Enable theme preview during selection                   |
-| consult-preview-yank       | t   | Enable yank preview during selection                   |
-| consult-preview-mark       | t   | Enable mark preview during selection                    |
 | consult-preview-line       | t   | Enable line preview during selection                    |
+| consult-preview-mark       | t   | Enable mark preview during selection                    |
 | consult-preview-outline    | t   | Enable outline preview during selection                 |
+| consult-preview-theme      | t   | Enable theme preview during selection                   |
+| consult-preview-yank       | t   | Enable yank preview during selection                    |
 | consult-themes             | nil | List of themes to be presented for selection            |
 
 ## Acknowledgements


### PR DESCRIPTION
This is a first draft regarding adopting the history command by @oantolin https://github.com/oantolin/completing-history.
I replace the command `consult-minibuffer-history` by a more general variant.

For now it is a bit simpler than the original and I would like to discuss a few things:

* ~Why not use minibuffer-history directly, why is there minibuffer-history-variable etc?~
  **EDIT**: I understand this now. It makes sense to have the indirection to allow overwriting the history from outside.
* ~In contrast to the original, I do not enable-recursive-minibuffers for now. I have them generally on but I am not sure if I should instead turn them on always for consult--read. I think I have to play around with them being turned off in order to understand if it makes sense. I am so accustomed to having them turned on...
**EDIT**: I have problems with this, I am really not accustomed to non-recursive-minibuffers...~
**EDIT2**: Resolved this. It makes sense to have this setting.
* ~Would it make sense to add an optional argument to the command which takes a history variable such that users can build there own history commands if there is a need, such that the auto-detection is not used? However one has to distinguish rings from minibuffer history variables.~
**EDIT**: I added a history argument for now. This makes it trivial to implement `consult-minibuffer-history` again.
* ~It would also be an option to keep the `consult-minibuffer-history` command. I am not sure if it is better to have a dwim command or have multiple more specialised commands. Very often I like dwim commands. Maybe have both?~
**EDIT**: I don't think there is a need for `consult-minibuffer-history`. If there is, just use `consult-history` with a custom argument.
* ~Due to the design of consult, the command is bound nowhere, so this won't be an exact substitute for the command by @oantolin. But I think the command could be bound to a C-c key and if it is available it can be used if not it reports "History is empty". We could make the error more precise, showing "History not available, configure consult-history-rings" for example.~
**EDIT**: I implemented the more precise error.
* I contrast to the original, I do not modify inhibit-read-only, I don't see why this command should get a special treatment. Should it?
* In contrast to the original, I do not query the command-history. It was queried when repeating. Keep it? Note that there is still consult-command-history, which executes commands.

Ping @oantolin @clemera @manuel-uberti for opinions. It seems I have many more questions than answers here.