### PR TITLE
Split package, such that consult.el depends only on Emacs core components

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,10 +99,12 @@ completions with richer information (e.g. `M-x`, `describe-face`,
     and recursive editing.
   * `consult-outline`: Jump to a heading of the outline. Supports live preview
     and recursive editing.
-  * `consult-flycheck`: Jump to flycheck error. Supports live preview
-    and recursive editing.
   * `consult-imenu`: Jump to imenu item. Supports live preview
     and recursive editing.
+  * `consult-flycheck`: Jump to flycheck error. Supports live preview
+    and recursive editing. This command requires to install the additional
+    `consult-flycheck.el` package since the main `consult.el` package
+    only depends on Emacs core components.
 
 ### Miscellaneous
 
@@ -150,9 +152,7 @@ order to use the enhanced commands, you must configure the keybindings yourself.
          ("M-g i" . consult-imenu)   ;; "M-s i" is a good alternative
          ("M-s m" . consult-multi-occur)
          ("M-y" . consult-yank-pop)
-         ("<help> a" . consult-apropos)
-         :map flycheck-command-map
-         ("!" . consult-flycheck))
+         ("<help> a" . consult-apropos))
 
   ;; The :init configuration is always executed (Not lazy!)
   :init
@@ -166,6 +166,16 @@ order to use the enhanced commands, you must configure the keybindings yourself.
   ;; Optionally enable previews. Note that individual previews can be disabled
   ;; via customization variables.
   (consult-preview-mode))
+
+;; Enable Consult-Selectrum integration.
+;; This should be installed if Selectrum is used.
+(use-package consult-selectrum
+  :demand t)
+
+;; Install the consult-flycheck command.
+(use-package consult-flycheck
+  :bind (:map flycheck-command-map
+         ("!" . consult-flycheck)))
 
 ;; Optionally enable richer annotations using the Marginalia package
 (use-package marginalia
@@ -184,6 +194,7 @@ order to use the enhanced commands, you must configure the keybindings yourself.
 | consult-line-numbers-widen | t   | Show absolute line numbers when narrowing is active.    |
 | consult-mode-histories     | …   | Mode-specific history variables                         |
 | consult-preview-buffer     | t   | Enable buffer preview during selection                  |
+| consult-preview-flycheck   | t   | Enable flycheck error preview during selection          |
 | consult-preview-line       | t   | Enable line preview during selection                    |
 | consult-preview-mark       | t   | Enable mark preview during selection                    |
 | consult-preview-outline    | t   | Enable outline preview during selection                 |
@@ -196,8 +207,10 @@ order to use the enhanced commands, you must configure the keybindings yourself.
 
 It is recommended to install the following package combination:
 
-* selectrum or icomplete-vertical: Vertical completion systems
 * consult: This package
+* consult-flycheck: Provides the consult-flycheck command.
+* consult-selectrum: Provides integration with Selectrum.
+* selectrum or icomplete-vertical: Vertical completion systems
 * marginalia: Annotations for the completion candidates
 * embark: Action commands, which can act on the completion candidates
 * orderless or prescient: Completion style, filters the candidates, Prescient also offers sorting.
@@ -220,6 +233,8 @@ Advice and useful discussions:
 * [Clemens Radermacher](https://github.com/clemera/)
 * [Omar Antolín Camarena](https://github.com/oantolin/)
 * [Protesilaos Stavrou](https://gitlab.com/protesilaos/)
+* [Steve Purcell](https://gitlab.com/purcell/)
+* [Adam Porter](https://gitlab.com/alphapapa/)
 
 Code contributions:
 * [Omar Antolín Camarena](https://github.com/oantolin/)

--- a/consult-flycheck.el
+++ b/consult-flycheck.el
@@ -1,0 +1,87 @@
+;;; consult-flycheck.el --- Provides the command `consult-flycheck'  -*- lexical-binding: t; -*-
+
+;; Author: Daniel Mendler, Consult and Selectrum contributors
+;; Maintainer: Daniel Mendler
+;; Created: 2020
+;; License: GPL-3.0-or-later
+;; Version: 0.1
+;; Package-Requires: ((consult "0.1") (flycheck "31") (emacs "26.1"))
+;; Homepage: https://github.com/minad/consult
+
+;; This file is not part of GNU Emacs.
+
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Provides the command `consult-flycheck'. This is an extra package, since the
+;; consult.el package only depends on Emacs core components.
+
+;;; Code:
+
+(require 'consult)
+(require 'flycheck)
+
+(defcustom consult-preview-flycheck t
+  "Enable flycheck preview during selection."
+  :type 'boolean
+  :group 'consult)
+
+(defun consult--flycheck-candidates ()
+  "Return flycheck errors as alist."
+  (consult--forbid-minibuffer)
+  (unless (require 'flycheck nil t)
+    (error "Package `flycheck' is not installed"))
+  (unless flycheck-current-errors
+    (user-error "No flycheck errors (Status: %s)" flycheck-last-status-change))
+  (let* ((errors (mapcar
+                  (lambda (err)
+                    (list (file-name-nondirectory (flycheck-error-filename err))
+                          (number-to-string (flycheck-error-line err))
+                          err))
+                  (seq-sort #'flycheck-error-level-< flycheck-current-errors)))
+         (file-width (apply #'max (mapcar (lambda (x) (length (car x))) errors)))
+         (line-width (apply #'max (mapcar (lambda (x) (length (cadr x))) errors)))
+         (fmt (format "%%-%ds %%-%ds %%-7s %%s (%%s)" file-width line-width)))
+    (mapcar
+     (pcase-lambda (`(,file ,line ,err))
+       (flycheck-jump-to-error err)
+       (cons
+        (format fmt
+                (propertize file 'face 'flycheck-error-list-filename)
+                (propertize line 'face 'flycheck-error-list-line-number)
+                (let ((level (flycheck-error-level err)))
+                  (propertize (symbol-name level) 'face (flycheck-error-level-error-list-face level)))
+                (propertize (flycheck-error-message err)
+                            'face 'flycheck-error-list-error-message)
+                (propertize (symbol-name (flycheck-error-checker err))
+                            'face 'flycheck-error-list-checker-name))
+        (point-marker)))
+     errors)))
+
+;;;###autoload
+(defun consult-flycheck ()
+  "Jump to flycheck error."
+  (interactive)
+  (consult--goto
+   (consult--read "Flycheck error: "
+                  (consult--with-increased-gc (consult--flycheck-candidates))
+                  :category 'flycheck-error
+                  :require-match t
+                  :sort nil
+                  :lookup #'consult--lookup-list
+                  :preview (and consult-preview-flycheck #'consult--preview-position))))
+
+(provide 'consult-flycheck)
+;;; consult-flycheck.el ends here

--- a/consult-flycheck.el
+++ b/consult-flycheck.el
@@ -41,8 +41,6 @@
 (defun consult--flycheck-candidates ()
   "Return flycheck errors as alist."
   (consult--forbid-minibuffer)
-  (unless (require 'flycheck nil t)
-    (error "Package `flycheck' is not installed"))
   (unless flycheck-current-errors
     (user-error "No flycheck errors (Status: %s)" flycheck-last-status-change))
   (let* ((errors (mapcar

--- a/consult-selectrum.el
+++ b/consult-selectrum.el
@@ -25,8 +25,10 @@
 
 ;;; Commentary:
 
-;; The Selectrum integration for Consult ensures that previews work when using Selectrum.
-;; Furthermore, some minor Selectrum-specific `completing-read' tweaks are applied.
+;; The Selectrum integration for Consult ensures that previews work when using
+;; Selectrum. Furthermore, some minor Selectrum-specific `completing-read'
+;; tweaks are applied. This is an extra package, since the consult.el package
+;; only depends on Emacs core components.
 
 ;;; Code:
 

--- a/consult-selectrum.el
+++ b/consult-selectrum.el
@@ -1,0 +1,79 @@
+;;; consult-selectrum.el --- Selectrum integration for Consult  -*- lexical-binding: t; -*-
+
+;; Author: Daniel Mendler, Consult and Selectrum contributors
+;; Maintainer: Daniel Mendler
+;; Created: 2020
+;; License: GPL-3.0-or-later
+;; Version: 0.1
+;; Package-Requires: ((consult "0.1") (selectrum "3.0") (emacs "26.1"))
+;; Homepage: https://github.com/minad/consult
+
+;; This file is not part of GNU Emacs.
+
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; The Selectrum integration for Consult ensures that previews work when using Selectrum.
+;; Furthermore, some minor Selectrum-specific `completing-read' tweaks are applied.
+
+;;; Code:
+
+(require 'consult)
+(require 'selectrum)
+
+(defun consult-selectrum--preview-update ()
+  "Preview function used for Selectrum."
+  (when-let* ((fun (car consult--preview-stack))
+              (cand (selectrum-get-current-candidate)))
+    (funcall fun cand)))
+
+(defun consult-selectrum--preview-setup ()
+  "Setup preview support for selectrum."
+  (advice-remove 'selectrum--minibuffer-post-command-hook #'consult-selectrum--preview-update)
+  (when consult-preview-mode
+    (advice-add 'selectrum--minibuffer-post-command-hook :after #'consult-selectrum--preview-update)))
+
+(consult--preview-register #'consult-selectrum--preview-setup)
+
+;; HACK: Hopefully selectrum adds something like this to the official API.
+;; https://github.com/raxod502/selectrum/issues/243
+;; https://github.com/raxod502/selectrum/pull/244
+(defsubst consult-selectrum--configure (options)
+  "Add OPTIONS to the next `selectrum-read' call."
+  (when (and options (bound-and-true-p selectrum-mode))
+    (letrec ((advice (lambda (orig prompt candidates &rest args)
+                       (advice-remove #'selectrum-read advice)
+                       (apply orig prompt candidates (append options args)))))
+      (advice-add #'selectrum-read :around advice))))
+
+;; HACK: We are explicitly injecting the default input, since default inputs are deprecated
+;; in the completing-read API. Selectrum's completing-read consequently does not support
+;; them. Maybe Selectrum should add support for initial inputs, even if this is deprecated
+;; since the argument does not seem to go away any time soon. There are a few special cases
+;; where one wants to use an initial input, even though it should not be overused and the use
+;; of initial inputs is discouraged by the Emacs documentation.
+(cl-defun consult-selectrum--read-advice (_prompt _candidates &rest rest &key default-top initial &allow-other-keys)
+  "Advice for `consult--read' performing Selectrum-specific configuration.
+
+_PROMPT, _CANDIDATES and REST are ignored.
+DEFAULT-TOP and INITIAL keyword arguments are used to configure Selectrum."
+  (consult-selectrum--configure
+   `(,@(unless default-top '(:no-move-default-candidate t))
+     ,@(when initial `(:initial-input ,initial)))))
+
+(advice-add #'consult--read :before #'consult-selectrum--read-advice)
+
+(provide 'consult-selectrum)
+;;; consult-selectrum.el ends here

--- a/consult-selectrum.el
+++ b/consult-selectrum.el
@@ -54,7 +54,7 @@
 ;; https://github.com/raxod502/selectrum/pull/244
 (defsubst consult-selectrum--configure (options)
   "Add OPTIONS to the next `selectrum-read' call."
-  (when (and options (bound-and-true-p selectrum-mode))
+  (when (and options selectrum-mode)
     (letrec ((advice (lambda (orig prompt candidates &rest args)
                        (advice-remove #'selectrum-read advice)
                        (apply orig prompt candidates (append options args)))))

--- a/consult.el
+++ b/consult.el
@@ -124,11 +124,6 @@ The histories can be rings or lists."
   :type 'boolean
   :group 'consult)
 
-(defcustom consult-preview-flycheck t
-  "Enable flycheck preview during selection."
-  :type 'boolean
-  :group 'consult)
-
 (defcustom consult-preview-imenu t
   "Enable imenu item preview during selection."
   :type 'boolean
@@ -232,18 +227,6 @@ nil shows all `custom-available-themes'."
 (defvar imenu-use-markers)
 (declare-function imenu--make-index-alist "imenu")
 (declare-function imenu--subalist-p "imenu")
-
-(defvar flycheck-current-errors)
-(defvar flycheck-last-status-change)
-(declare-function flycheck-error-buffer "flycheck")
-(declare-function flycheck-error-checker "flycheck")
-(declare-function flycheck-error-filename "flycheck")
-(declare-function flycheck-error-level "flycheck")
-(declare-function flycheck-error-level-< "flycheck")
-(declare-function flycheck-error-level-error-list-face "flycheck")
-(declare-function flycheck-error-line "flycheck")
-(declare-function flycheck-error-message "flycheck")
-(declare-function flycheck-jump-to-error "flycheck")
 
 ;;;; Helper functions
 
@@ -480,51 +463,6 @@ See `multi-occur' for the meaning of the arguments BUFS, REGEXP and NLINES."
                   :lookup #'consult--lookup-list
                   :history 'consult-outline-history
                   :preview (and consult-preview-outline #'consult--preview-position))))
-
-(defun consult--flycheck-candidates ()
-  "Return flycheck errors as alist."
-  (consult--forbid-minibuffer)
-  (unless (require 'flycheck nil t)
-    (error "Package `flycheck' is not installed"))
-  (unless flycheck-current-errors
-    (user-error "No flycheck errors (Status: %s)" flycheck-last-status-change))
-  (let* ((errors (mapcar
-                  (lambda (err)
-                    (list (file-name-nondirectory (flycheck-error-filename err))
-                          (number-to-string (flycheck-error-line err))
-                          err))
-                  (seq-sort #'flycheck-error-level-< flycheck-current-errors)))
-         (file-width (apply #'max (mapcar (lambda (x) (length (car x))) errors)))
-         (line-width (apply #'max (mapcar (lambda (x) (length (cadr x))) errors)))
-         (fmt (format "%%-%ds %%-%ds %%-7s %%s (%%s)" file-width line-width)))
-    (mapcar
-     (pcase-lambda (`(,file ,line ,err))
-       (flycheck-jump-to-error err)
-       (cons
-        (format fmt
-                (propertize file 'face 'flycheck-error-list-filename)
-                (propertize line 'face 'flycheck-error-list-line-number)
-                (let ((level (flycheck-error-level err)))
-                  (propertize (symbol-name level) 'face (flycheck-error-level-error-list-face level)))
-                (propertize (flycheck-error-message err)
-                            'face 'flycheck-error-list-error-message)
-                (propertize (symbol-name (flycheck-error-checker err))
-                            'face 'flycheck-error-list-checker-name))
-        (point-marker)))
-     errors)))
-
-;;;###autoload
-(defun consult-flycheck ()
-  "Jump to flycheck error."
-  (interactive)
-  (consult--goto
-   (consult--read "Flycheck error: "
-                  (consult--with-increased-gc (consult--flycheck-candidates))
-                  :category 'flycheck-error
-                  :require-match t
-                  :sort nil
-                  :lookup #'consult--lookup-list
-                  :preview (and consult-preview-flycheck #'consult--preview-position))))
 
 (defun consult--mark-candidates ()
   "Return alist of lines containing markers.

--- a/consult.el
+++ b/consult.el
@@ -1239,15 +1239,12 @@ It should check the consult-preview-mode flag and should be indempotent."
   (add-hook 'consult-preview-mode-hook hook)
   (funcall hook))
 
-;; TODO open questions
-;; 1. consult--preview-default-update checks for icomplete/selectrum, necessary or not?
-
 ;;;; default completion-system support for preview
 
 (defun consult--preview-default-update (&rest _)
   "Preview function used for the default completion system."
-  (unless (or (bound-and-true-p selectrum-mode)
-              (bound-and-true-p icomplete-mode))
+  ;; Check if the default completion-system is active, by looking at `completing-read-function'
+  (when (eq completing-read-function #'completing-read-default)
     (when-let (fun (car consult--preview-stack))
       (let ((cand (minibuffer-contents-no-properties)))
         (when (test-completion cand

--- a/consult.el
+++ b/consult.el
@@ -44,6 +44,7 @@
 
 (require 'bookmark)
 (require 'cl-lib)
+(require 'imenu)
 (require 'kmacro)
 (require 'outline)
 (require 'recentf)
@@ -220,13 +221,6 @@ nil shows all `custom-available-themes'."
 
 (defvar-local consult--overlays nil
   "List of overlays used by consult.")
-
-;;;; Pre-declarations for external packages
-
-(defvar imenu-auto-rescan)
-(defvar imenu-use-markers)
-(declare-function imenu--make-index-alist "imenu")
-(declare-function imenu--subalist-p "imenu")
 
 ;;;; Helper functions
 

--- a/consult.el
+++ b/consult.el
@@ -1209,7 +1209,7 @@ It should check the consult-preview-mode flag and should be indempotent."
 
 (defun consult--icomplete-preview-setup ()
   "Setup preview support for Icomplete."
-  (advice-remove 'icomplete-post-commanda-hook #'consult--icomplete-preview-update)
+  (advice-remove 'icomplete-post-command-hook #'consult--icomplete-preview-update)
   (when consult-preview-mode
     (advice-add 'icomplete-post-command-hook :after #'consult--icomplete-preview-update)))
 


### PR DESCRIPTION
The goal is to separate completion-system-specific logic completely from the rest. Selectrum-specific logic has been moved to consult-selectrum.el. Furthermore flycheck-specific has been moved to consult-flycheck.el.

Note, that there is still 'consult-buffer` which contains selectrum-specific code. This is not addressed here and ~will be adressed later, see discussion in #10.~ has been addressed in #55.

I think I am happy with now - the code is indeed cleaner since no completion-system specifics are mixed with the rest of the code. There is also no regression in behavior. The only disadvantage is that some users have to install three packages now. In contrast, for users who don't use flycheck/selectrum this is an advantage.