### PR TITLE
General support for narrowing prefixes (used by consult-buffer and consult-flycheck as of now) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,10 +99,12 @@ completions with richer information (e.g. `M-x`, `describe-face`,
     and recursive editing.
   * `consult-outline`: Jump to a heading of the outline. Supports live preview
     and recursive editing.
-  * `consult-flycheck`: Jump to flycheck error. Supports live preview
-    and recursive editing.
   * `consult-imenu`: Jump to imenu item. Supports live preview
     and recursive editing.
+  * `consult-flycheck`: Jump to flycheck error. Supports live preview
+    and recursive editing. This command requires to install the additional
+    `consult-flycheck.el` package since the main `consult.el` package
+    only depends on Emacs core components.
 
 ### Miscellaneous
 
@@ -150,9 +152,7 @@ order to use the enhanced commands, you must configure the keybindings yourself.
          ("M-g i" . consult-imenu)   ;; "M-s i" is a good alternative
          ("M-s m" . consult-multi-occur)
          ("M-y" . consult-yank-pop)
-         ("<help> a" . consult-apropos)
-         :map flycheck-command-map
-         ("!" . consult-flycheck))
+         ("<help> a" . consult-apropos))
 
   ;; The :init configuration is always executed (Not lazy!)
   :init
@@ -166,6 +166,16 @@ order to use the enhanced commands, you must configure the keybindings yourself.
   ;; Optionally enable previews. Note that individual previews can be disabled
   ;; via customization variables.
   (consult-preview-mode))
+
+;; Enable Consult-Selectrum integration.
+;; This should be installed if Selectrum is used.
+(use-package consult-selectrum
+  :demand t)
+
+;; Install the consult-flycheck command.
+(use-package consult-flycheck
+  :bind (:map flycheck-command-map
+         ("!" . consult-flycheck)))
 
 ;; Optionally enable richer annotations using the Marginalia package
 (use-package marginalia
@@ -184,6 +194,7 @@ order to use the enhanced commands, you must configure the keybindings yourself.
 | consult-line-numbers-widen | t   | Show absolute line numbers when narrowing is active.    |
 | consult-mode-histories     | …   | Mode-specific history variables                         |
 | consult-preview-buffer     | t   | Enable buffer preview during selection                  |
+| consult-preview-flycheck   | t   | Enable flycheck error preview during selection          |
 | consult-preview-line       | t   | Enable line preview during selection                    |
 | consult-preview-mark       | t   | Enable mark preview during selection                    |
 | consult-preview-outline    | t   | Enable outline preview during selection                 |
@@ -196,8 +207,10 @@ order to use the enhanced commands, you must configure the keybindings yourself.
 
 It is recommended to install the following package combination:
 
-* selectrum or icomplete-vertical: Vertical completion systems
 * consult: This package
+* consult-flycheck: Provides the consult-flycheck command.
+* consult-selectrum: Provides integration with Selectrum.
+* selectrum or icomplete-vertical: Vertical completion systems
 * marginalia: Annotations for the completion candidates
 * embark: Action commands, which can act on the completion candidates
 * orderless or prescient: Completion style, filters the candidates, Prescient also offers sorting.
@@ -220,6 +233,8 @@ Advice and useful discussions:
 * [Clemens Radermacher](https://github.com/clemera/)
 * [Omar Antolín Camarena](https://github.com/oantolin/)
 * [Protesilaos Stavrou](https://gitlab.com/protesilaos/)
+* [Steve Purcell](https://gitlab.com/purcell/)
+* [Adam Porter](https://gitlab.com/alphapapa/)
 
 Code contributions:
 * [Omar Antolín Camarena](https://github.com/oantolin/)

--- a/README.md
+++ b/README.md
@@ -188,20 +188,20 @@ order to use the enhanced commands, you must configure the keybindings yourself.
 
 ### Configuration settings
 
-| Variable                   | Def | Description                                             |
-|----------------------------|-----|---------------------------------------------------------|
-| consult-line-numbers-widen | t   | Show absolute line numbers when narrowing is active.    |
-| consult-mode-histories     | …   | Mode-specific history variables                         |
-| consult-narrow-separator   | …   | Separator shown after narrowing prefix                  |
-| consult-preview-buffer     | t   | Enable buffer preview during selection                  |
-| consult-preview-flycheck   | t   | Enable flycheck error preview during selection          |
-| consult-preview-line       | t   | Enable line preview during selection                    |
-| consult-preview-mark       | t   | Enable mark preview during selection                    |
-| consult-preview-outline    | t   | Enable outline preview during selection                 |
-| consult-preview-theme      | t   | Enable theme preview during selection                   |
-| consult-preview-yank       | t   | Enable yank preview during selection                    |
-| consult-recenter           | t   | Recenter after jumping to a location                    |
-| consult-themes             | nil | List of themes to be presented for selection            |
+| Variable                    | Default   | Description                                             |
+|-----------------------------|-----------|---------------------------------------------------------|
+| consult-after-jump-function | 'recenter | Function to call after jumping to a location            |
+| consult-line-numbers-widen  | t         | Show absolute line numbers when narrowing is active.    |
+| consult-mode-histories      | …         | Mode-specific history variables                         |
+| consult-narrow-separator    | "[ZWSP]"  | Separator shown after narrowing prefix                  |
+| consult-preview-buffer      | t         | Enable buffer preview during selection                  |
+| consult-preview-flycheck    | t         | Enable flycheck error preview during selection          |
+| consult-preview-line        | t         | Enable line preview during selection                    |
+| consult-preview-mark        | t         | Enable mark preview during selection                    |
+| consult-preview-outline     | t         | Enable outline preview during selection                 |
+| consult-preview-theme       | t         | Enable theme preview during selection                   |
+| consult-preview-yank        | t         | Enable yank preview during selection                    |
+| consult-themes              | nil       | List of themes to be presented for selection            |
 
 ## Related packages
 

--- a/README.md
+++ b/README.md
@@ -54,11 +54,9 @@ Most provided commands follow the naming scheme `consult-<thing>`.
 
   * `consult-buffer` (`-other-window`, `-other-frame`): Enhanced version of
      `switch-to-buffer` with support for virtual buffers. Supports live preview
-     and recursive editing while previewing. If Selectrum is used
-     `consult-buffer` supports prefixes for narrowing. You can type `b SPC`, `f
-     SPC`, `m SPC` and `v SPC` in order to narrow to buffers, files, bookmarks
-     and views respectively. Unfortunately this is (not yet?) supported by the
-     generic `completing-read` implementation.
+     and recursive editing while previewing. The command supports narrowing. You
+     can type `b SPC`, `f SPC`, `m SPC` and `v SPC` in order to narrow to
+     buffers, files, bookmarks and views respectively.
   * `consult-bookmark`: Select or create bookmark. You might prefer the more
     powerful `consult-buffer` instead, which includes bookmarks.
   * `consult-recent-file` (`-other-window`, `-other-frame`): Select a recent
@@ -101,10 +99,11 @@ completions with richer information (e.g. `M-x`, `describe-face`,
     and recursive editing.
   * `consult-imenu`: Jump to imenu item. Supports live preview
     and recursive editing.
-  * `consult-flycheck`: Jump to flycheck error. Supports live preview
-    and recursive editing. This command requires to install the additional
-    `consult-flycheck.el` package since the main `consult.el` package
-    only depends on Emacs core components.
+  * `consult-flycheck`: Jump to flycheck error. Supports live preview and
+    recursive editing. The command supports narrowing. Press `e SPC`, `w SPC`,
+    `i SPC` to only show errors, warnings and infos respectively. This command
+    requires to install the additional `consult-flycheck.el` package since the
+    main `consult.el` package only depends on Emacs core components.
 
 ### Miscellaneous
 
@@ -193,6 +192,7 @@ order to use the enhanced commands, you must configure the keybindings yourself.
 |----------------------------|-----|---------------------------------------------------------|
 | consult-line-numbers-widen | t   | Show absolute line numbers when narrowing is active.    |
 | consult-mode-histories     | …   | Mode-specific history variables                         |
+| consult-narrow-separator   | …   | Separator shown after narrowing prefix                  |
 | consult-preview-buffer     | t   | Enable buffer preview during selection                  |
 | consult-preview-flycheck   | t   | Enable flycheck error preview during selection          |
 | consult-preview-line       | t   | Enable line preview during selection                    |

--- a/consult-flycheck.el
+++ b/consult-flycheck.el
@@ -55,17 +55,21 @@
     (mapcar
      (pcase-lambda (`(,file ,line ,err))
        (flycheck-jump-to-error err)
-       (cons
-        (format fmt
-                (propertize file 'face 'flycheck-error-list-filename)
-                (propertize line 'face 'flycheck-error-list-line-number)
-                (let ((level (flycheck-error-level err)))
-                  (propertize (symbol-name level) 'face (flycheck-error-level-error-list-face level)))
-                (propertize (flycheck-error-message err)
-                            'face 'flycheck-error-list-error-message)
-                (propertize (symbol-name (flycheck-error-checker err))
-                            'face 'flycheck-error-list-checker-name))
-        (point-marker)))
+       (let ((level (flycheck-error-level err)))
+         (cons
+          (consult--narrow-candidate
+           (pcase level
+             ('error "e")
+             ('warning "w")
+             (_ "i"))
+           (format fmt
+                   (propertize file 'face 'flycheck-error-list-filename)
+                   (propertize line 'face 'flycheck-error-list-line-number)
+                   (propertize (symbol-name level) 'face (flycheck-error-level-error-list-face level))
+                   (propertize (flycheck-error-message err) 'face 'flycheck-error-list-error-message)
+                   (propertize (symbol-name (flycheck-error-checker err))
+                            'face 'flycheck-error-list-checker-name)))
+        (point-marker))))
      errors)))
 
 ;;;###autoload
@@ -78,6 +82,7 @@
                   :category 'flycheck-error
                   :require-match t
                   :sort nil
+                  :narrow '("e" "w" "i")
                   :lookup #'consult--lookup-list
                   :preview (and consult-preview-flycheck #'consult--preview-position))))
 

--- a/consult-flycheck.el
+++ b/consult-flycheck.el
@@ -1,0 +1,87 @@
+;;; consult-flycheck.el --- Provides the command `consult-flycheck'  -*- lexical-binding: t; -*-
+
+;; Author: Daniel Mendler, Consult and Selectrum contributors
+;; Maintainer: Daniel Mendler
+;; Created: 2020
+;; License: GPL-3.0-or-later
+;; Version: 0.1
+;; Package-Requires: ((consult "0.1") (flycheck "31") (emacs "26.1"))
+;; Homepage: https://github.com/minad/consult
+
+;; This file is not part of GNU Emacs.
+
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Provides the command `consult-flycheck'. This is an extra package, since the
+;; consult.el package only depends on Emacs core components.
+
+;;; Code:
+
+(require 'consult)
+(require 'flycheck)
+
+(defcustom consult-preview-flycheck t
+  "Enable flycheck preview during selection."
+  :type 'boolean
+  :group 'consult)
+
+(defun consult--flycheck-candidates ()
+  "Return flycheck errors as alist."
+  (consult--forbid-minibuffer)
+  (unless (require 'flycheck nil t)
+    (error "Package `flycheck' is not installed"))
+  (unless flycheck-current-errors
+    (user-error "No flycheck errors (Status: %s)" flycheck-last-status-change))
+  (let* ((errors (mapcar
+                  (lambda (err)
+                    (list (file-name-nondirectory (flycheck-error-filename err))
+                          (number-to-string (flycheck-error-line err))
+                          err))
+                  (seq-sort #'flycheck-error-level-< flycheck-current-errors)))
+         (file-width (apply #'max (mapcar (lambda (x) (length (car x))) errors)))
+         (line-width (apply #'max (mapcar (lambda (x) (length (cadr x))) errors)))
+         (fmt (format "%%-%ds %%-%ds %%-7s %%s (%%s)" file-width line-width)))
+    (mapcar
+     (pcase-lambda (`(,file ,line ,err))
+       (flycheck-jump-to-error err)
+       (cons
+        (format fmt
+                (propertize file 'face 'flycheck-error-list-filename)
+                (propertize line 'face 'flycheck-error-list-line-number)
+                (let ((level (flycheck-error-level err)))
+                  (propertize (symbol-name level) 'face (flycheck-error-level-error-list-face level)))
+                (propertize (flycheck-error-message err)
+                            'face 'flycheck-error-list-error-message)
+                (propertize (symbol-name (flycheck-error-checker err))
+                            'face 'flycheck-error-list-checker-name))
+        (point-marker)))
+     errors)))
+
+;;;###autoload
+(defun consult-flycheck ()
+  "Jump to flycheck error."
+  (interactive)
+  (consult--goto
+   (consult--read "Flycheck error: "
+                  (consult--with-increased-gc (consult--flycheck-candidates))
+                  :category 'flycheck-error
+                  :require-match t
+                  :sort nil
+                  :lookup #'consult--lookup-list
+                  :preview (and consult-preview-flycheck #'consult--preview-position))))
+
+(provide 'consult-flycheck)
+;;; consult-flycheck.el ends here

--- a/consult-flycheck.el
+++ b/consult-flycheck.el
@@ -41,8 +41,6 @@
 (defun consult--flycheck-candidates ()
   "Return flycheck errors as alist."
   (consult--forbid-minibuffer)
-  (unless (require 'flycheck nil t)
-    (error "Package `flycheck' is not installed"))
   (unless flycheck-current-errors
     (user-error "No flycheck errors (Status: %s)" flycheck-last-status-change))
   (let* ((errors (mapcar

--- a/consult-selectrum.el
+++ b/consult-selectrum.el
@@ -47,7 +47,11 @@
   (when consult-preview-mode
     (advice-add 'selectrum--minibuffer-post-command-hook :after #'consult-selectrum--preview-update)))
 
-(consult--preview-register #'consult-selectrum--preview-setup)
+(add-hook 'consult-preview-mode-hook #'consult-selectrum--preview-setup)
+(consult-selectrum--preview-setup) ;; call immediately to ensure load-order independence
+
+(add-hook 'consult--minibuffer-map-hook
+          (lambda () (when selectrum-mode selectrum-minibuffer-map)))
 
 ;; HACK: Hopefully selectrum adds something like this to the official API.
 ;; https://github.com/raxod502/selectrum/issues/243

--- a/consult-selectrum.el
+++ b/consult-selectrum.el
@@ -25,8 +25,10 @@
 
 ;;; Commentary:
 
-;; The Selectrum integration for Consult ensures that previews work when using Selectrum.
-;; Furthermore, some minor Selectrum-specific `completing-read' tweaks are applied.
+;; The Selectrum integration for Consult ensures that previews work when using
+;; Selectrum. Furthermore, some minor Selectrum-specific `completing-read'
+;; tweaks are applied. This is an extra package, since the consult.el package
+;; only depends on Emacs core components.
 
 ;;; Code:
 

--- a/consult-selectrum.el
+++ b/consult-selectrum.el
@@ -1,0 +1,79 @@
+;;; consult-selectrum.el --- Selectrum integration for Consult  -*- lexical-binding: t; -*-
+
+;; Author: Daniel Mendler, Consult and Selectrum contributors
+;; Maintainer: Daniel Mendler
+;; Created: 2020
+;; License: GPL-3.0-or-later
+;; Version: 0.1
+;; Package-Requires: ((consult "0.1") (selectrum "3.0") (emacs "26.1"))
+;; Homepage: https://github.com/minad/consult
+
+;; This file is not part of GNU Emacs.
+
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; The Selectrum integration for Consult ensures that previews work when using Selectrum.
+;; Furthermore, some minor Selectrum-specific `completing-read' tweaks are applied.
+
+;;; Code:
+
+(require 'consult)
+(require 'selectrum)
+
+(defun consult-selectrum--preview-update ()
+  "Preview function used for Selectrum."
+  (when-let* ((fun (car consult--preview-stack))
+              (cand (selectrum-get-current-candidate)))
+    (funcall fun cand)))
+
+(defun consult-selectrum--preview-setup ()
+  "Setup preview support for selectrum."
+  (advice-remove 'selectrum--minibuffer-post-command-hook #'consult-selectrum--preview-update)
+  (when consult-preview-mode
+    (advice-add 'selectrum--minibuffer-post-command-hook :after #'consult-selectrum--preview-update)))
+
+(consult--preview-register #'consult-selectrum--preview-setup)
+
+;; HACK: Hopefully selectrum adds something like this to the official API.
+;; https://github.com/raxod502/selectrum/issues/243
+;; https://github.com/raxod502/selectrum/pull/244
+(defsubst consult-selectrum--configure (options)
+  "Add OPTIONS to the next `selectrum-read' call."
+  (when (and options (bound-and-true-p selectrum-mode))
+    (letrec ((advice (lambda (orig prompt candidates &rest args)
+                       (advice-remove #'selectrum-read advice)
+                       (apply orig prompt candidates (append options args)))))
+      (advice-add #'selectrum-read :around advice))))
+
+;; HACK: We are explicitly injecting the default input, since default inputs are deprecated
+;; in the completing-read API. Selectrum's completing-read consequently does not support
+;; them. Maybe Selectrum should add support for initial inputs, even if this is deprecated
+;; since the argument does not seem to go away any time soon. There are a few special cases
+;; where one wants to use an initial input, even though it should not be overused and the use
+;; of initial inputs is discouraged by the Emacs documentation.
+(cl-defun consult-selectrum--read-advice (_prompt _candidates &rest rest &key default-top initial &allow-other-keys)
+  "Advice for `consult--read' performing Selectrum-specific configuration.
+
+_PROMPT, _CANDIDATES and REST are ignored.
+DEFAULT-TOP and INITIAL keyword arguments are used to configure Selectrum."
+  (consult-selectrum--configure
+   `(,@(unless default-top '(:no-move-default-candidate t))
+     ,@(when initial `(:initial-input ,initial)))))
+
+(advice-add #'consult--read :before #'consult-selectrum--read-advice)
+
+(provide 'consult-selectrum)
+;;; consult-selectrum.el ends here

--- a/consult-selectrum.el
+++ b/consult-selectrum.el
@@ -54,7 +54,7 @@
 ;; https://github.com/raxod502/selectrum/pull/244
 (defsubst consult-selectrum--configure (options)
   "Add OPTIONS to the next `selectrum-read' call."
-  (when (and options (bound-and-true-p selectrum-mode))
+  (when (and options selectrum-mode)
     (letrec ((advice (lambda (orig prompt candidates &rest args)
                        (advice-remove #'selectrum-read advice)
                        (apply orig prompt candidates (append options args)))))

--- a/consult.el
+++ b/consult.el
@@ -124,11 +124,6 @@ The histories can be rings or lists."
   :type 'boolean
   :group 'consult)
 
-(defcustom consult-preview-flycheck t
-  "Enable flycheck preview during selection."
-  :type 'boolean
-  :group 'consult)
-
 (defcustom consult-preview-imenu t
   "Enable imenu item preview during selection."
   :type 'boolean
@@ -232,18 +227,6 @@ nil shows all `custom-available-themes'."
 (defvar imenu-use-markers)
 (declare-function imenu--make-index-alist "imenu")
 (declare-function imenu--subalist-p "imenu")
-
-(defvar flycheck-current-errors)
-(defvar flycheck-last-status-change)
-(declare-function flycheck-error-buffer "flycheck")
-(declare-function flycheck-error-checker "flycheck")
-(declare-function flycheck-error-filename "flycheck")
-(declare-function flycheck-error-level "flycheck")
-(declare-function flycheck-error-level-< "flycheck")
-(declare-function flycheck-error-level-error-list-face "flycheck")
-(declare-function flycheck-error-line "flycheck")
-(declare-function flycheck-error-message "flycheck")
-(declare-function flycheck-jump-to-error "flycheck")
 
 ;;;; Helper functions
 
@@ -480,51 +463,6 @@ See `multi-occur' for the meaning of the arguments BUFS, REGEXP and NLINES."
                   :lookup #'consult--lookup-list
                   :history 'consult-outline-history
                   :preview (and consult-preview-outline #'consult--preview-position))))
-
-(defun consult--flycheck-candidates ()
-  "Return flycheck errors as alist."
-  (consult--forbid-minibuffer)
-  (unless (require 'flycheck nil t)
-    (error "Package `flycheck' is not installed"))
-  (unless flycheck-current-errors
-    (user-error "No flycheck errors (Status: %s)" flycheck-last-status-change))
-  (let* ((errors (mapcar
-                  (lambda (err)
-                    (list (file-name-nondirectory (flycheck-error-filename err))
-                          (number-to-string (flycheck-error-line err))
-                          err))
-                  (seq-sort #'flycheck-error-level-< flycheck-current-errors)))
-         (file-width (apply #'max (mapcar (lambda (x) (length (car x))) errors)))
-         (line-width (apply #'max (mapcar (lambda (x) (length (cadr x))) errors)))
-         (fmt (format "%%-%ds %%-%ds %%-7s %%s (%%s)" file-width line-width)))
-    (mapcar
-     (pcase-lambda (`(,file ,line ,err))
-       (flycheck-jump-to-error err)
-       (cons
-        (format fmt
-                (propertize file 'face 'flycheck-error-list-filename)
-                (propertize line 'face 'flycheck-error-list-line-number)
-                (let ((level (flycheck-error-level err)))
-                  (propertize (symbol-name level) 'face (flycheck-error-level-error-list-face level)))
-                (propertize (flycheck-error-message err)
-                            'face 'flycheck-error-list-error-message)
-                (propertize (symbol-name (flycheck-error-checker err))
-                            'face 'flycheck-error-list-checker-name))
-        (point-marker)))
-     errors)))
-
-;;;###autoload
-(defun consult-flycheck ()
-  "Jump to flycheck error."
-  (interactive)
-  (consult--goto
-   (consult--read "Flycheck error: "
-                  (consult--with-increased-gc (consult--flycheck-candidates))
-                  :category 'flycheck-error
-                  :require-match t
-                  :sort nil
-                  :lookup #'consult--lookup-list
-                  :preview (and consult-preview-flycheck #'consult--preview-position))))
 
 (defun consult--mark-candidates ()
   "Return alist of lines containing markers.

--- a/consult.el
+++ b/consult.el
@@ -246,9 +246,11 @@ For each completion system, a function must be added here.")
 
 ;;;; Helper functions
 
+;; Same function as marginalia--align
 (defsubst consult--align (str)
   "Align STR at the right margin."
   (concat
+   " "
    (propertize
     " "
     'display

--- a/consult.el
+++ b/consult.el
@@ -323,6 +323,7 @@ CHARS is the list of narrowing prefix strings."
   "Setup narrowing in BODY.
 
 CHARS is the list of narrowing prefix strings."
+  (declare (indent 1))
   (let ((chars-var (make-symbol "chars")))
     `(let ((,chars-var ,chars))
        (if ,chars-var
@@ -419,33 +420,30 @@ PREVIEW is a preview function.
 NARROW is a list of narrowing prefix strings."
   (ignore default-top)
   ;; supported types
-  (cl-assert (or (functionp candidates) ;; function
-                 (not candidates) ;; nil
+  (cl-assert (or (not candidates) ;; nil
                  (obarrayp candidates) ;; obarray
                  (stringp (car candidates)) ;; string list
                  (consp (car candidates)))) ;; alist
-  (let* ((candidates-fun (if (functionp candidates) candidates (lambda () candidates)))
-         (candidate-table
-          (if (and sort (not category) (not (functionp candidates)))
-              candidates
-            (lambda (str pred action)
-              (if (eq action 'metadata)
-                  `(metadata
-                    ,@(if category `((category . ,category)))
-                    ,@(if (not sort) '((cycle-sort-function . identity)
-                                       (display-sort-function . identity))))
-                (complete-with-action action (funcall candidates-fun) str pred))))))
+  (let ((candidates-fun
+         (if (and sort (not category))
+             candidates
+           (lambda (str pred action)
+             (if (eq action 'metadata)
+                 `(metadata
+                   ,@(if category `((category . ,category)))
+                   ,@(if (not sort) '((cycle-sort-function . identity)
+                                      (display-sort-function . identity))))
+               (complete-with-action action candidates str pred))))))
     (consult--with-preview preview
         (cand state)
         (funcall preview 'save nil nil)
         (funcall preview 'restore cand state)
-        (when-let (cand (funcall lookup (funcall candidates-fun) cand))
+        (when-let (cand (funcall lookup candidates cand))
           (funcall preview 'preview cand nil))
       (funcall
-       lookup
-       (funcall candidates-fun)
+       lookup candidates
        (consult--with-narrow narrow
-         (completing-read prompt candidate-table
+         (completing-read prompt candidates-fun
                           predicate require-match initial history default))))))
 
 (defsubst consult--pad-line-number (width line)

--- a/consult.el
+++ b/consult.el
@@ -290,9 +290,11 @@ PREVIEW is the preview function."
            (consult--preview-install ,preview-var (lambda () ,@body))
          ,@body))))
 
-(defsubst consult--narrow-prefix (prefix)
-  "Make narrowing prefix string from PREFIX."
-  (propertize (concat prefix consult-narrow-separator " ") 'display ""))
+(defsubst consult--narrow-candidate (prefix &rest strings)
+  "Add narrowing prefix PREFIX and concatenate with STRINGS."
+  (apply #'concat
+         (propertize (concat prefix consult-narrow-separator " ") 'display "")
+         strings))
 
 (defun consult--narrow-install (chars body)
   "Install narrowing in BODY.
@@ -975,8 +977,8 @@ FACE is the face for the candidate.
 ANN is the annotation string at the right margin.
 FUN is the function used to open the candiddate."
   (list
-   (concat
-    (consult--narrow-prefix prefix)
+   (consult--narrow-candidate
+    prefix
     (propertize cand 'face face)
     (consult--align (propertize ann 'face 'consult-annotation)))
    fun

--- a/consult.el
+++ b/consult.el
@@ -1239,15 +1239,12 @@ It should check the consult-preview-mode flag and should be indempotent."
   (add-hook 'consult-preview-mode-hook hook)
   (funcall hook))
 
-;; TODO open questions
-;; 1. consult--preview-default-update checks for icomplete/selectrum, necessary or not?
-
 ;;;; default completion-system support for preview
 
 (defun consult--preview-default-update (&rest _)
   "Preview function used for the default completion system."
-  (unless (or (bound-and-true-p selectrum-mode)
-              (bound-and-true-p icomplete-mode))
+  ;; Check if the default completion-system is active, by looking at `completing-read-function'
+  (when (eq completing-read-function #'completing-read-default)
     (when-let (fun (car consult--preview-stack))
       (let ((cand (minibuffer-contents-no-properties)))
         (when (test-completion cand

--- a/consult.el
+++ b/consult.el
@@ -44,6 +44,7 @@
 
 (require 'bookmark)
 (require 'cl-lib)
+(require 'imenu)
 (require 'kmacro)
 (require 'outline)
 (require 'recentf)
@@ -220,13 +221,6 @@ nil shows all `custom-available-themes'."
 
 (defvar-local consult--overlays nil
   "List of overlays used by consult.")
-
-;;;; Pre-declarations for external packages
-
-(defvar imenu-auto-rescan)
-(defvar imenu-use-markers)
-(declare-function imenu--make-index-alist "imenu")
-(declare-function imenu--subalist-p "imenu")
 
 ;;;; Helper functions
 

--- a/consult.el
+++ b/consult.el
@@ -182,7 +182,12 @@ nil shows all `custom-available-themes'."
   :group 'consult)
 
 (defcustom consult-narrow-separator (string 8203) ;; zero width space
-  "String used to separate prefix for narrowing."
+  "String used to separate prefix for narrowing.
+
+This string should ideally be made of unique characters,
+such that no accidential matching occurs. Therefore
+the default is a zero-width-space, which generally
+does not occur in candidate strings."
   :type 'string
   :group 'consult)
 

--- a/consult.el
+++ b/consult.el
@@ -166,9 +166,12 @@ nil shows all `custom-available-themes'."
   :type '(repeat symbol)
   :group 'consult)
 
-(defcustom consult-recenter t
-  "Recenter after jumping."
-  :type 'boolean
+(defcustom consult-after-jump-function #'recenter
+  "Function called after jumping to a location.
+
+This is called during preview and for the final jump. This function can be
+overwritten for example to achieve pulsing."
+  :type 'symbol
   :group 'consult)
 
 (defcustom consult-line-numbers-widen t
@@ -362,10 +365,10 @@ CHARS is the list of narrowing prefix strings."
   (mapc #'delete-overlay consult--overlays)
   (setq consult--overlays nil))
 
-(defsubst consult--recenter ()
-  "Recenter point."
-  (when consult-recenter
-    (recenter)))
+(defsubst consult--after-jump ()
+  "Execute the after jump function."
+  (when consult-after-jump-function
+    (funcall consult-after-jump-function)))
 
 (defsubst consult--goto-1 (pos)
   "Go to POS and recenter."
@@ -373,7 +376,7 @@ CHARS is the list of narrowing prefix strings."
     (when (and (markerp pos) (not (eq (current-buffer) (marker-buffer pos))))
       (switch-to-buffer (marker-buffer pos)))
     (goto-char pos)
-    (consult--recenter)))
+    (consult--after-jump)))
 
 (defsubst consult--goto (pos)
   "Push current position to mark ring, go to POS and recenter."
@@ -1182,7 +1185,7 @@ Prepend PREFIX in front of all items."
     :lookup #'consult--lookup-list
     :history 'consult-imenu-history
     :sort nil))
-  (consult--recenter))
+  (consult--after-jump))
 
 ;;;###autoload
 (define-minor-mode consult-preview-mode

--- a/consult.el
+++ b/consult.el
@@ -181,7 +181,7 @@ nil shows all `custom-available-themes'."
   :type 'integer
   :group 'consult)
 
-(defcustom consult-narrow-separator "#"
+(defcustom consult-narrow-separator (string 8203) ;; zero width space
   "String used to separate prefix for narrowing."
   :type 'string
   :group 'consult)

--- a/consult.el
+++ b/consult.el
@@ -1209,7 +1209,7 @@ It should check the consult-preview-mode flag and should be indempotent."
 
 (defun consult--icomplete-preview-setup ()
   "Setup preview support for Icomplete."
-  (advice-remove 'icomplete-post-commanda-hook #'consult--icomplete-preview-update)
+  (advice-remove 'icomplete-post-command-hook #'consult--icomplete-preview-update)
   (when consult-preview-mode
     (advice-add 'icomplete-post-command-hook :after #'consult--icomplete-preview-update)))
 


### PR DESCRIPTION
I implemented the low-tech consult-buffer solution. I prefix everything with "b#" etc. The prefix is hidden with the display property which is nice. However in order to narrow one has to press "b # SPC" and this is worse than the old behavior. Furthermore there is no support for showing invisible buffers anymore. The consult--buffer-selectrum implementation supported pressing SPC and then only the invisible buffers where shown.

~I don't like it.~ Now I do!

See #10.

Ping @clemera @oantolin 

**UPDATE**: I prefix everything with "b [zero-width-space]". Then I modify the keymap such that if pressing space after a prefix character like "b", it inserts "[zero-width-space] SPC". This works nicely, allows widening by deleting the prefix characters again etc. I am happy with the solution. It is reasonably low-tech. No dynamic candidates. Only the keymap tweak.