### PR TITLE
Use different approach to install narrow setup

### DIFF
--- a/consult-selectrum.el
+++ b/consult-selectrum.el
@@ -50,11 +50,6 @@
 (add-hook 'consult-preview-mode-hook #'consult-selectrum--preview-setup)
 (consult-selectrum--preview-setup) ;; call immediately to ensure load-order independence
 
-(add-hook 'consult--minibuffer-map-hook
-          (lambda ()
-            (when (eq completing-read-function #'selectrum-completing-read)
-              selectrum-minibuffer-map)))
-
 ;; HACK: Hopefully selectrum adds something like this to the official API.
 ;; https://github.com/raxod502/selectrum/issues/243
 ;; https://github.com/raxod502/selectrum/pull/244

--- a/consult.el
+++ b/consult.el
@@ -286,7 +286,7 @@ PREVIEW is the preview function."
          (propertize (concat prefix consult-narrow-separator " ") 'display "")
          strings))
 
-(defun consult-insert ()
+(defun consult-insert-for-narrow ()
   "Insert narrowing prefix, see `consult-narrow-separator'."
   (interactive)
   (insert (concat consult-narrow-separator " ")))
@@ -304,7 +304,7 @@ CHARS is the list of narrowing prefix strings."
                            (&optional _)
                            (let ((str (minibuffer-contents)))
                              (when (member str chars)
-                               'consult-insert)))))
+                               'consult-insert-for-narrow)))))
           (use-local-map keymap)))
     (funcall body)))
 

--- a/consult.el
+++ b/consult.el
@@ -297,7 +297,7 @@ PREVIEW is the preview function."
 CHARS is the list of narrowing prefix strings."
   (minibuffer-with-setup-hook
       (lambda ()
-        (let ((keymap (copy-keymap (current-local-map))))
+        (let ((keymap (make-composed-keymap nil (current-local-map))))
           (define-key keymap " "
             `(menu-item "" nil :filter
                         ,(lambda

--- a/consult.el
+++ b/consult.el
@@ -297,7 +297,7 @@ PREVIEW is the preview function."
 CHARS is the list of narrowing prefix strings."
   (minibuffer-with-setup-hook
       (lambda ()
-        (let ((keymap (make-composed-keymap (current-local-map) nil)))
+        (let ((keymap (copy-keymap (current-local-map))))
           (define-key keymap " "
             `(menu-item "" nil :filter
                         ,(lambda


### PR DESCRIPTION
This simplifies the way the keymap gets setup which allows removing the `consult--minibuffer-map-hook` and the menu filter for `SPC` also makes sure the `C-h k` works as expected and if `SPC` is bound to something else than `self-insert-command` it will continue to do so. 