### PR TITLE
Fix issue #48

### DIFF
--- a/consult.el
+++ b/consult.el
@@ -772,11 +772,8 @@ The arguments and expected return value are as specified for
             (concat (substring initial 0 limit) (car all)))
            (t (let ((enable-recursive-minibuffers t))
                 (if (eq category 'file)
-                    (read-file-name "Completion: "
-                                    (file-name-directory initial)
-                                    initial t
-                                    (file-name-nondirectory initial)
-                                    predicate)
+                    (read-file-name
+                     "Completion: " initial initial t nil predicate)
                   (completing-read
                    "Completion: " collection predicate t initial)))))))
     (if (null completion)


### PR DESCRIPTION
When completing files with consult-completion-in-region, the point in
the minibuffer gets placed initially at the beginning of the last path
component. With this change it starts at the end of minibuffer
contents, as for other types of completion.