### PR TITLE
make git grep/grep/rg commands and regexps customizable

### DIFF
--- a/consult.el
+++ b/consult.el
@@ -2170,23 +2170,25 @@ used. See also `consult-imenu'."
   (interactive)
   (consult--imenu (consult--project-imenu-items)))
 
-(defconst consult--grep-regexp "\\([^\0\n]+\\)\0\\([^:\0]+\\)[:\0]"
-  "Regexp used to match file and line of grep output.")
+(defcustom consult-grep-regexp "\\([^\0\n]+\\)\0\\([^:\0]+\\)[:\0]"
+  "Regexp used to match file and line of grep output."
+  :type 'regexp)
 
-(defconst consult--grep-match-regexp "\e\\[[0-9;]+m\\(.*?\\)\e\\[[0-9;]*m"
-  "Regexp used to find matches in grep output.")
+(defcustom consult-grep-match-regexp "\e\\[[0-9;]+m\\(.*?\\)\e\\[[0-9;]*m"
+  "Regexp used to find matches in grep output."
+  :type 'regexp)
 
 (defun consult--grep-matches (lines)
   "Find grep match for REGEXP in LINES."
   (let ((candidates))
     (save-match-data
       (dolist (str lines)
-        (when (string-match consult--grep-regexp str)
+        (when (string-match consult-grep-regexp str)
           (let* ((file (expand-file-name (consult--strip-ansi-escape (match-string 1 str))))
                  (line (string-to-number (consult--strip-ansi-escape (match-string 2 str))))
                  (str (substring str (match-end 0)))
                  (loc (consult--format-location (file-relative-name file) line)))
-            (while (string-match consult--grep-match-regexp str)
+            (while (string-match consult-grep-match-regexp str)
               (setq str (concat (substring str 0 (match-beginning 0))
                                 (propertize (substring (match-string 1 str)) 'face 'consult-preview-match)
                                 (substring str (match-end 0)))))
@@ -2215,9 +2217,25 @@ OPEN is the function to open new files."
               (forward-char (caddr loc)))
             (point-marker)))))))
 
-(defvar consult--git-grep-command '("git" "--no-pager" "grep" "--null" "--color=always" "--extended-regexp" "--line-number" "-I" "-e"))
-(defvar consult--grep-command '("grep" "--null" "--line-buffered" "--color=always" "--extended-regexp" "--exclude-dir=.git" "--line-number" "-I" "-r" "." "-e"))
-(defvar consult--ripgrep-command '("rg" "--null" "--line-buffered" "--color=always" "--max-columns=500" "--no-heading" "--line-number" "." "-e"))
+(defcustom consult-git-grep-command '("git" "--no-pager" "grep"
+                                      "--null" "--color=always"
+                                      "--extended-regexp" "--line-number"
+                                      "-I" "-e")
+  "Command and arguments for git grep."
+  :type '(repeat :tag "Argument List" string))
+
+(defcustom consult-grep-command '("grep" "--null" "--line-buffered"
+                                  "--color=always" "--extended-regexp"
+                                  "--exclude-dir=.git" "--line-number"
+                                  "-I" "-r" "." "-e")
+  "Command and arguments for grep."
+  :type '(repeat :tag "Argument List" string))
+
+(defcustom consult-ripgrep-command '("rg" "--null" "--line-buffered"
+                                     "--color=always" "--max-columns=500"
+                                     "--no-heading" "--line-number" "." "-e")
+  "Command and arguments for rg."
+  :type '(repeat :tag "Argument List" string))
 
 (defun consult--command-args (cmd)
   "Split command arguments and append to CMD."
@@ -2259,19 +2277,19 @@ PROMPT is the prompt string."
 (defun consult-grep (&optional dir initial)
   "Search for regexp with grep in DIR with INITIAL input."
   (interactive "P")
-  (consult--grep "Grep" consult--grep-command dir initial))
+  (consult--grep "Grep" consult-grep-command dir initial))
 
 ;;;###autoload
 (defun consult-git-grep (&optional dir initial)
   "Search for regexp with grep in DIR with INITIAL input."
   (interactive "P")
-  (consult--grep "Git-grep" consult--git-grep-command dir initial))
+  (consult--grep "Git-grep" consult-git-grep-command dir initial))
 
 ;;;###autoload
 (defun consult-ripgrep (&optional dir initial)
   "Search for regexp with rg in DIR with INITIAL input."
   (interactive "P")
-  (consult--grep "Ripgrep" consult--ripgrep-command dir initial))
+  (consult--grep "Ripgrep" consult-ripgrep-command dir initial))
 
 (defun consult--find-async (cmd)
   "Async function for `consult--find'.


### PR DESCRIPTION
Hello,

I saw the announcement on r/emacs about consul-grep and I wanted to give it a shot since it seems awesome.

I'm not able to use neither consult-git-grep, consult-grep nor consult-ripgrep.  For consul-grep the answer is easy: I'm on OpenBSD and grep here doesn't accept all the arguments that gnu grep does.  In most cases it has the single letter option (i.e. `-n` instead of `--line-number`, `-E` instead of `--extended-regexp` etc), but there are some flags that aren't supported (in particular `-Z/--null`).

consul-git-grep fails because it uses `/usr/bin/grep` under the hood? probably.  The most puzzling is why ripgrep doesn't work.

(Sorry for not being too specific, "doesn't work" doesn't really mean anything, but I don't know what it's not working.  When I type something at the prompt the various consult-git-grep/grep/ripgrep a red exclamation mark appears right after "Grep" in the prompt and that's all).

This is a first step though, I'm proposing to make the various `-command` part of the public API and thus customizables, as well as the regexps, so folks like me can tune 'em for their specific `grep` implementations.

Cheers!