### PR TITLE
add consult-man

### DIFF
--- a/consult.el
+++ b/consult.el
@@ -201,6 +201,11 @@ You may want to add a function which pulses the current line, e.g.,
   "Command line arguments for locate."
   :type '(repeat string))
 
+(defcustom consult-man-command
+  '("man" "-k")
+  "Command line arguments for man apropos."
+  :type '(repeat string))
+
 (defcustom consult-preview-key 'any
   "Preview trigger, can be nil, 'any or a key."
   :type '(choice (const nil) (const any) vector))
@@ -311,6 +316,7 @@ Each element of the list must have the form '(handler char name)."
 (defvar consult--error-history nil)
 (defvar consult--grep-history nil)
 (defvar consult--find-history nil)
+(defvar consult--man-history nil)
 (defvar consult--line-history nil)
 (defvar consult--apropos-history nil)
 (defvar consult--theme-history nil)
@@ -2417,6 +2423,33 @@ CMD is the find argument list."
     :category 'file
     :history '(:input consult--find-history))))
 
+(defun consult--man-async (cmd)
+  "Async function for `consult--man'.
+
+CMD is the man argument list."
+  (thread-first (consult--async-sink)
+    (consult--async-refresh-timer)
+    (consult--async-process (consult--command-args cmd))
+    (consult--async-throttle)
+    (consult--async-split)))
+
+(defun consult--man (prompt cmd initial)
+  "Run man CMD with INITIAL input.
+
+PROMPT is the prompt.
+CMD is the man argument list."
+  (let ((match (consult--read
+                prompt
+                (consult--man-async cmd)
+                :sort nil
+                :require-match t
+                :initial (concat consult-async-default-split initial)
+                :add-history (concat consult-async-default-split (thing-at-point 'symbol))
+                ;; XXX: category?
+                :history '(:input consult--man-history))))
+    (string-match "\\([^[:blank:]]+\\) - " match)
+    (man (match-string 1 match))))
+
 ;;;###autoload
 (defun consult-find (&optional dir initial)
   "Search for regexp with find in DIR with INITIAL input."
@@ -2430,6 +2463,12 @@ CMD is the find argument list."
   "Search for regexp with locate with INITIAL input."
   (interactive)
   (consult--find "Locate: " consult-locate-command initial))
+
+;;;##autoload
+(defun consult-man (&optional initial)
+  "Search for regexp with apropos with INITIAL input."
+  (interactive)
+  (consult--man "Man: " consult-man-command initial))
 
 ;;;; default completion-system support
 


### PR DESCRIPTION
Hello,

This adds the ability to search for a manual page using `man -k`.

Note: this was tested only on OpenBSD, which uses `mandoc`.  Mandoc is used also by various linux distribution, void linux for instance comes to mind, but not all.  Unfortunately I cannot test this on other systems and I don't have knowledge on difference between `man`/`apropos` implementations.

It's different (and more powerful) than the `M-x man` command because it allows to search on the content of the manpages (and use the apropos expression syntax) instead of only searching on the page name.  To be clear: with this I can type `Va=optind` and see all the manual pages where the variable `optind` is mentioned, something that's not possible with `M-x man`.

Another thing: it would be nice if we could split the user input on spaces: this will allows us to make better use of the expression syntax.  For instance, I can

```
$ apropos =.cf =.cnf =.conf
```

to list all the manpages whose description matches ".cf", "cnf" or ".conf".  This pr calls man with arg `("man" "-k" ".cf .cnf .conf")`, we should call it with `("man" "-k" ".cf" ".cnf" ".conf")`.

(a note about the name: I initially called it `consult-apropos` because I intented to use apropos(1), but then I saw that there is already an `consult-apropos`, for emacs' apropos, so I changed the name to `consult-man` and changed `consult-man-command` to "man -k" to be more consistent.)