### PR TITLE
Add consult-keep-lines function

### DIFF
--- a/consult.el
+++ b/consult.el
@@ -1610,12 +1610,12 @@ The symbol at point and the last `isearch-string' is added to the future history
       :initial initial
       :preview (consult--preview-position)))))
 
-(defun consult-keep-lines (&optional intial)
+(defun consult-keep-lines ()
   "Select a subset of the lines in the current buffer with live preview.
 
 The lines selected are those that match the minibuffer input
 according to the current `completion-styles'. This command obeys
-narrowing. Optionally INITIAL input can be provided."
+narrowing."
   (interactive)
 
   (consult--fontify-all)

--- a/consult.el
+++ b/consult.el
@@ -1627,14 +1627,15 @@ narrowing."
         (success t)
         lines)
 
-    (save-excursion
-      (let ((pos (point-min)) end)
-        (while (< pos (point-max))
-          (goto-char pos)
-          (setq end (line-end-position))
-          (push (buffer-substring pos end) lines)
-          (setq pos (1+ end)))))
-    (setq lines (nreverse lines))
+    (consult--with-increased-gc
+     (save-excursion
+       (let ((pos (point-min)) end)
+         (while (< pos (point-max))
+           (goto-char pos)
+           (setq end (line-end-position))
+           (push (buffer-substring pos end) lines)
+           (setq pos (1+ end)))))
+     (setq lines (nreverse lines)))
 
     (minibuffer-with-setup-hook
         (lambda ()

--- a/consult.el
+++ b/consult.el
@@ -1649,8 +1649,9 @@ narrowing."
                  (when last (setcdr last nil)) ; make it a proper list
                  (with-current-buffer buffer
                    (when font-lock-mode (font-lock-mode -1))
-                   (delete-region (point-min) (point-max))
-                   (insert (string-join filtered "\n"))
+                   (atomic-change-group
+                     (delete-region (point-min) (point-max))
+                     (insert (string-join filtered "\n")))
                    (goto-char (point-min))))))
            nil t))
       (unwind-protect

--- a/consult.el
+++ b/consult.el
@@ -1622,39 +1622,51 @@ narrowing."
 
   (let ((buffer (current-buffer))
         (font-lock-originally font-lock-mode)
+        (original-point (point))
+        (changes (prepare-change-group))
+        (success t)
         lines)
 
-    (save-excursion
-      (consult--with-increased-gc
+    (consult--with-increased-gc
+     (save-excursion
        (let ((pos (point-min)) end)
          (while (< pos (point-max))
            (goto-char pos)
            (setq end (line-end-position))
            (push (buffer-substring pos end) lines)
            (setq pos (1+ end)))))
-      (setq lines (nreverse lines))
+     (setq lines (nreverse lines)))
 
-      (atomic-change-group
-        (minibuffer-with-setup-hook
-            (lambda ()
-              (add-hook
-               'after-change-functions
-               (lambda (&rest _)
-                 (while-no-input
-                   (let* ((input (minibuffer-contents-no-properties))
-                          (filtered (completion-all-completions input lines nil 0))
-                          (last (last filtered)))
-                     (when last (setcdr last nil)) ; make it a proper list
-                     (with-current-buffer buffer
-                       (when font-lock-mode (font-lock-mode -1))
-                       (delete-region (point-min) (point-max))
-                       (insert (string-join filtered "\n"))
-                       (goto-char (point-min))))))
-               nil t))
-          (unwind-protect
-              (read-from-minibuffer "Keep lines: ")
-            (when (and font-lock-originally (not font-lock-mode))
-              (font-lock-mode))))))))
+    (minibuffer-with-setup-hook
+        (lambda ()
+          (add-hook
+           'after-change-functions
+           (lambda (&rest _)
+             (while-no-input
+               (let* ((input (minibuffer-contents-no-properties))
+                      (filtered (completion-all-completions input lines nil 0))
+                      (last (last filtered)))
+                 (when last (setcdr last nil)) ; make it a proper list
+                 (with-current-buffer buffer
+                   (when font-lock-mode (font-lock-mode -1))
+                   (atomic-change-group
+                     (delete-region (point-min) (point-max))
+                     (insert (string-join filtered "\n")))
+                   (goto-char (point-min))))))
+           nil t))
+      (unwind-protect
+          (progn
+            (activate-change-group changes)
+            (condition-case nil
+                (read-from-minibuffer "Keep lines: ")
+              (quit (setq success nil))))
+        (undo-amalgamate-change-group changes)
+        (when (and font-lock-originally (not font-lock-mode))
+          (font-lock-mode))
+        (if success
+            (accept-change-group changes)
+          (cancel-change-group changes)
+          (goto-char original-point))))))
 
 ;;;###autoload
 (defun consult-goto-line ()

--- a/consult.el
+++ b/consult.el
@@ -1610,6 +1610,7 @@ The symbol at point and the last `isearch-string' is added to the future history
       :initial initial
       :preview (consult--preview-position)))))
 
+;;;###autoload
 (defun consult-keep-lines ()
   "Select a subset of the lines in the current buffer with live preview.
 


### PR DESCRIPTION
Here's the keep-lines function we discussed. The increased-gc seemed to take care of the last remaining performance issues after switching to actual buffer manipulation instead of overlays.