### PR TITLE
Dirty hack to test transient popup with consult-grep

### DIFF
--- a/consult-grep-popup.el
+++ b/consult-grep-popup.el
@@ -1,0 +1,31 @@
+;;; consult-grep-popup.el --- Popup for grep-consult -*- lexical-binding: t -*-
+(require 'consult)
+
+(defun consult-grep-popup-update (args)
+  "Update current search with ARGS."
+  (if args
+      (insert (concat " -- " (mapconcat 'identity args " ")))))
+
+(setq grep-popup-function #'consult-grep-popup-update)
+
+(defun consult-grep-args ()
+  "Edit `consult-grep' args with a popup."
+  (interactive)
+  (if (minibufferp)
+      (let* ((input (consult-grep-args--split (minibuffer-contents-no-properties)))
+             (grep-popup-args (cdr input)))
+        (kill-region (minibuffer-prompt-end) (point-max))
+        (insert (car input))
+        (grep-popup))
+    (message "Not in minibuffer!")))
+
+(defun consult-grep-args--split (input)
+  "Split INPUT into cmd and args."
+  (let* ((parts (split-string input " +-- +"))
+         (cmd (or (car parts) ""))
+         (args (split-string (or (cadr parts) "") " ")))
+    (cons cmd args)))
+
+(define-key consult-async-map (kbd "M-h") #'consult-grep-args)
+(provide 'consult-consult-grep-popup)
+;;; consult-consult-grep-popup.el ends here

--- a/consult.el
+++ b/consult.el
@@ -1202,7 +1202,7 @@ The refresh happens after a DELAY, defaulting to `consult-async-refresh-delay'."
   "Split command arguments and append to CMD."
   (lambda (input)
     (let ((args (split-string input " +-- +")))
-      (append cmd (list (car args)) grep-popup-args))))
+      (append cmd (list (car args)) (mapcan #'split-string (cdr args))))))
 
 (defmacro consult--async-command (cmd &rest transforms)
   "Asynchronous CMD pipeline with TRANSFORMS."
@@ -2945,25 +2945,6 @@ See `consult-grep' for more details regarding the asynchronous search."
 
 (with-eval-after-load 'icomplete (require 'consult-icomplete))
 (with-eval-after-load 'selectrum (require 'consult-selectrum))
-
-(require 'transient)
-
-(defvar grep-popup-args nil)
-
-(defun grep-popup-update ()
-  "Update current search."
-  (interactive)
-  (let ((args (transient-args 'grep-popup)))
-    (setq grep-popup-args args)))
-
-(define-transient-command grep-popup ()
-  "Search popup."
-  ["Matching control"
-   ("-i" "Ignore case" "--ignore-case")]
-  ["Search"
-   ("s" "update search" grep-popup-update)])
-
-(define-key consult-async-map (kbd "M-h") #'grep-popup)
 
 ;; Local Variables:
 ;; outline-regexp: ";;;;* \\|(def\\(un\\|custom\\|var\\) consult-[a-z]"

--- a/consult.el
+++ b/consult.el
@@ -1202,7 +1202,7 @@ The refresh happens after a DELAY, defaulting to `consult-async-refresh-delay'."
   "Split command arguments and append to CMD."
   (lambda (input)
     (let ((args (split-string input " +-- +")))
-      (append cmd (list (car args)) (mapcan #'split-string (cdr args))))))
+      (append cmd (list (car args)) grep-popup-args))))
 
 (defmacro consult--async-command (cmd &rest transforms)
   "Asynchronous CMD pipeline with TRANSFORMS."
@@ -2945,6 +2945,25 @@ See `consult-grep' for more details regarding the asynchronous search."
 
 (with-eval-after-load 'icomplete (require 'consult-icomplete))
 (with-eval-after-load 'selectrum (require 'consult-selectrum))
+
+(require 'transient)
+
+(defvar grep-popup-args nil)
+
+(defun grep-popup-update ()
+  "Update current search."
+  (interactive)
+  (let ((args (transient-args 'grep-popup)))
+    (setq grep-popup-args args)))
+
+(define-transient-command grep-popup ()
+  "Search popup."
+  ["Matching control"
+   ("-i" "Ignore case" "--ignore-case")]
+  ["Search"
+   ("s" "update search" grep-popup-update)])
+
+(define-key consult-async-map (kbd "M-h") #'grep-popup)
 
 ;; Local Variables:
 ;; outline-regexp: ";;;;* \\|(def\\(un\\|custom\\|var\\) consult-[a-z]"

--- a/grep-popup.el
+++ b/grep-popup.el
@@ -1,0 +1,116 @@
+;;; grep-popup.el --- grep popup
+
+;;; Commentary:
+
+;;; Code:
+
+(require 'transient)
+
+(defgroup grep-popup nil
+  "Interactive search with grep."
+  :group 'tools
+  :group 'matching)
+
+(defvar grep-popup-args nil
+  "Args to initialize the `grep-popup' with.")
+
+(defcustom grep-popup-function 'ignore
+  "Function to perform the search.
+
+This function must take two parameters: the first one is the
+directory, the second one is a list of args for the search."
+  :type 'function)
+
+(defclass grep-popup-prefix (transient-prefix) nil)
+
+(cl-defmethod transient-init-value ((obj grep-popup-prefix))
+  (oset obj value grep-popup-args))
+
+(transient-define-argument grep-popup:--color ()
+  :description "Use markers to highlight the matching strings"
+  :class 'transient-switches
+  :key "=c"
+  :argument-format "--color=%s"
+  :argument-regexp "\\(--color=\\(auto\\|always\\|never\\)\\)"
+  :choices '("auto" "always" "never"))
+
+(transient-define-argument grep-popup:--binary-files ()
+  :description "Assume that binary files are TYPE"
+  :class 'transient-switches
+  :key "=b"
+  :argument-format "--binary-files=%s"
+  :argument-regexp "\\(--binary-files=\\(binary\\|text\\|without-match\\)\\)"
+  :choices '("binary" "text" "without-match"))
+
+;;;###autoload
+(defun grep-popup-search ()
+  "Update current search."
+  (interactive)
+  (let ((args (transient-args 'grep-popup)))
+    (setq grep-popup-args args)
+    (funcall grep-popup-function args)))
+
+(defun grep-popup--read-number-N+ (prompt initial-input history)
+  "Read a natural number (excluding zero) and return it as a string."
+  (transient--suspend-override t)
+  (let* ((enable-recursive-minibuffers t)
+         (input (transient-read-number-N+ prompt initial-input history)))
+    (transient--resume-override t)
+    input))
+
+(defun grep-popup--read-regexp (prompt initial-input history)
+  "Read regexp arg for interactive grep using `read-regexp'."
+  (interactive)
+  (transient--suspend-override t)
+  (let* ((enable-recursive-minibuffers t)
+         (input (read-regexp prompt initial-input history)))
+    (transient--resume-override t)
+    input))
+
+(define-transient-command grep-popup ()
+  "Search popup using `grep'."
+  :class 'grep-popup-prefix
+  [["Pattern Syntax"
+    ("-E" "Extended regexp" "--extended-regexp")
+    ("-F" "Fixed strings" "--fixed-strings")
+    ("-G" "Basic regexp" "--basic-regexp")
+    ("-P" "Perl regexp" "--perl-regexp")]
+   ["Matching control"
+    ("-i" "Ignore case" "--ignore-case")
+    ("-v" "Invert match" "--invert-match")
+    ("-w" "Word regexp" "--word-regexp")
+    ("-x" "Line regexp" "--line-regexp")]]
+  ["General output control"
+   ("-c" "Count" "--count")
+   (grep-popup:--color)
+   (5 "-L" "Files without match" "--files-without-match")
+   (5 "-l" "Files with match" "--files-with-match")
+   ("-m" "Max count" "--max-count=" grep-popup--read-number-N+)
+   ("-o" "Only matching" "--only-matching")
+   (5 "-q" "Quiet" "--quiet")
+   (5 "-s" "No messages" "--no-messages")]
+  ["Output line prefix control"
+   (5 "-b" "Byte offset" "--byte-offset")
+   ("-H" "With filename" "--with-filename")
+   (5 "-h" "No filename" "--no-filename")
+   ("-n" "Line number" "--line-number")
+   (5 "-T" "Initial tab" "--initial-tab")
+   (5 "-u" "Unix byte offsets" "--unix-byte-offsets")
+   ("-Z" "Output zero byte after filename" "--null")]
+  ["Context line control"
+   ("-A" "Print NUM lines of trailing context" "--after-context=" grep-popup--read-number-N+)
+   ("-B" "Print NUM lines of leading context" "--before-context=" grep-popup--read-number-N+)
+   ("-C" "Print NUM lines of output context" "--context=" grep-popup--read-number-N+)
+   (5 "-U" "Do not strip CR characters at EOL (MSDOS/Windows)" "--binary")]
+  ["File and directory selection"
+   (grep-popup:--binary-files)
+   (5 "-a" "Process a binary file as if it were text" "--text")
+   (5 "-I" "Process a binary file as if it did not contain matching data")
+   ("-r" "Read all files under each directory" "--recursive")
+   ("-R" "Like -r but follow all symlinks" "--dereference-recursive")
+   ("=i" "Include" "--include=" grep-popup--read-regexp)]
+  ["Search"
+   ("s" "in current directory" grep-popup-search)])
+
+(provide 'grep-popup)
+;;; grep-popup.el ends here


### PR DESCRIPTION
Here's a quick and dirty hack to test how a transient popup could work with consult. 

I created a tiny popup to change one single argument and I modified the `consult--command-args` method so it gets the arguments from a variable instead of the minibuffer.

So let's give it a try:
- Execute `consult-grep`
- Search for something that should work but with an uppercase char: **defU**
- Hit `M-h`
- Toggle the `-i` argument and hit `s` to update the search arguments
- Add another character to force the update: **defUn** (I told you it was dirty :suspect:)
- Rejoice with the case insensitive search