### PR TITLE
Isearch history

### DIFF
--- a/README.org
+++ b/README.org
@@ -253,6 +253,12 @@ variables and functions with their descriptions.
  - =consult-history=: Insert a string from the current buffer history.
    This command can be invoked from the minibuffer. In that case the
    history stored in the =minibuffer-history-variable= is used.
+ - =consult-isearch=: During an Isearch session, this command picks a
+   search string from history. Outside of Isearch, it reads a string
+   from the minibuffer and starts searching; this is useful, for
+   instance, as an Embark action. (Note that Isearch does not normally
+   read from the minibuffer. What you see at the bottom of the screen
+   is the echo area!)
 
 ** Major and minor modes
  :properties:
@@ -492,6 +498,14 @@ the box with the default completion, Icomplete and Selectrum.
           ("M-y" . consult-yank-pop)
           ("<help> a" . consult-apropos))
 
+   ;; Bind `consult-isearch' if desired.  The example below overloads
+   ;; it with `consult-history', so that you can access the search
+   ;; history with the same key, but only after starting Isearch.  Of
+   ;; course you can bind the command to a dedicated key in the global
+   ;; map instead.
+   :bind (:map isearch-mode-map
+          ("C-c h" . consult-isearch))
+
    ;; The :init configuration is always executed (Not lazy!)
    :init
 
@@ -545,6 +559,11 @@ the box with the default completion, Icomplete and Selectrum.
  (use-package consult-flycheck
    :bind (:map flycheck-command-map
                ("!" . consult-flycheck)))
+
+ ;; Optionally integrate `consult-isearch' with Embark.
+ (use-package embark
+   :bind (:map embark-general-map
+          ("C-s" . consult-isearch)))
  #+end_src
 
 ** Customizable variables

--- a/consult.el
+++ b/consult.el
@@ -2431,6 +2431,19 @@ In order to select from a specific HISTORY, pass the history variable as argumen
 
 ;;;;; Command: consult-isearch
 
+(defun consult--isearch-category (cand)
+  "The Isearch mode of history element CAND, encoded as a character."
+  (let* ((props (plist-member (text-properties-at 0 cand)
+                              'isearch-regexp-function))
+         (fun (cadr props)))
+    (cond ((null props) ?r)
+          ((null fun) ?l)
+          ((eq fun t) ?w)
+          ((eq fun 'word-search-regexp) ?w)
+          ((eq fun 'isearch-symbol-regexp) ?_)
+          ((eq fun 'char-fold-to-regexp) ?')
+          (t ?c))))
+
 ;;;###autoload
 (defun consult-isearch ()
   "Read a search string with completion from history.
@@ -2440,18 +2453,35 @@ starts a new Isearch session otherwise."
   (interactive)
   (let ((isearch-message-function 'ignore) ;; Avoid flicker in echo area
         (inhibit-redisplay t))             ;; Avoid flicker in mode line
-    (unless isearch-mode
-      (isearch-mode t))
+    (unless isearch-mode (isearch-mode t))
     (with-isearch-suspended
-     (setq isearch-new-string
-           (consult--read
-            "History: "
-            (if isearch-regexp regexp-search-ring search-ring)
-            :history t
-            :sort nil))
-     (setq isearch-new-message
-           (mapconcat 'isearch-text-char-description
-		      isearch-new-string "")))))
+     (let* ((hist (if (eq t search-default-mode)
+                      (append regexp-search-ring search-ring)
+                    (append search-ring regexp-search-ring)))
+            (str (consult--read
+                  "History: "
+                  hist
+                  :category 'isearch-string
+                  :history t
+                  :sort nil
+                  :narrow `(,(lambda (cand)
+                               (eq (consult--isearch-category cand)
+                                   consult--narrow))
+                            (?' . "Char-fold")
+                            (?c . "Custom")
+                            (?l . "Literal")
+                            (?r . "Regexp")
+                            (?_ . "Symbol")
+                            (?w . "Word")))))
+       ;; We need to preserve the `isearch-regexp-function' text property
+       (setq str (or (car (member str hist)) str))
+       (setq isearch-new-string str)
+       (setq isearch-new-message
+             (mapconcat 'isearch-text-char-description str ""))))
+    (when (eq ?r (consult--isearch-category isearch-string))
+      ;; This only works outside of `with-isearch-suspended'!
+      (setq isearch-regexp t)
+      (setq isearch-regexp-function nil))))
 
 ;;;;; Command: consult-minor-mode-menu
 

--- a/consult.el
+++ b/consult.el
@@ -2443,8 +2443,7 @@ starts a new Isearch session otherwise."
    (setq isearch-new-string
          (consult--read
           "History: "
-          (or (if isearch-regexp regexp-search-ring search-ring)
-              (user-error "History is empty"))
+          (if isearch-regexp regexp-search-ring search-ring)
           :history t
           :sort nil))
    (setq isearch-new-message

--- a/consult.el
+++ b/consult.el
@@ -2429,14 +2429,16 @@ In order to select from a specific HISTORY, pass the history variable as argumen
       (delete-minibuffer-contents))
     (insert (substring-no-properties str))))
 
-;;;;; Command: consult-isearch-history
+;;;;; Command: consult-isearch
 
 ;;;###autoload
-(defun consult-isearch-history ()
-  "In Isearch, select a search string from history."
+(defun consult-isearch ()
+  "Read a search string with completion from history.
+
+This replaces the current search string if Isearch is active, and
+starts a new Isearch session otherwise."
   (interactive)
-  (unless isearch-mode
-    (user-error "Command must be called during Isearch."))
+  (unless isearch-mode (isearch-mode t))
   (with-isearch-suspended
    (setq isearch-new-string
          (consult--read

--- a/consult.el
+++ b/consult.el
@@ -2431,6 +2431,10 @@ In order to select from a specific HISTORY, pass the history variable as argumen
 
 ;;;;; Command: consult-isearch
 
+(defun consult--isearch-read (hist)
+  (let ((str (consult--read "History: " hist :history t :sort nil)))
+     (cons str (mapconcat 'isearch-text-char-description str ""))))
+
 ;;;###autoload
 (defun consult-isearch ()
   "Read a search string with completion from history.
@@ -2438,17 +2442,24 @@ In order to select from a specific HISTORY, pass the history variable as argumen
 This replaces the current search string if Isearch is active, and
 starts a new Isearch session otherwise."
   (interactive)
-  (unless isearch-mode (isearch-mode t))
-  (with-isearch-suspended
-   (setq isearch-new-string
-         (consult--read
-          "History: "
-          (if isearch-regexp regexp-search-ring search-ring)
-          :history t
-          :sort nil))
-   (setq isearch-new-message
-         (mapconcat 'isearch-text-char-description
-		    isearch-new-string ""))))
+  (let* ((hist (if (if isearch-mode isearch-regexp
+                    (eq t search-default-mode))
+                  regexp-search-ring
+                 search-ring)))
+    (if isearch-mode
+        (with-isearch-suspended
+         (pcase-let ((`(,str . ,msg) (consult--isearch-read
+                                      (if isearch-regexp
+                                          regexp-search-ring
+                                        search-ring))))
+           (setq isearch-new-string str isearch-new-message msg)))
+      (pcase-let ((`(,str . ,msg) (consult--isearch-read
+                                   (if (eq t search-default-mode)
+                                       regexp-search-ring
+                                     search-ring))))
+        (isearch-mode t)
+        (with-isearch-suspended
+         (setq isearch-new-string str isearch-new-message msg))))))
 
 ;;;;; Command: consult-minor-mode-menu
 

--- a/consult.el
+++ b/consult.el
@@ -2429,6 +2429,26 @@ In order to select from a specific HISTORY, pass the history variable as argumen
       (delete-minibuffer-contents))
     (insert (substring-no-properties str))))
 
+;;;;; Command: consult-isearch-history
+
+;;;###autoload
+(defun consult-isearch-history ()
+  "In Isearch, select a search string from history."
+  (interactive)
+  (unless isearch-mode
+    (user-error "Command must be called during Isearch."))
+  (with-isearch-suspended
+   (setq isearch-new-string
+         (consult--read
+          "History: "
+          (or (if isearch-regexp regexp-search-ring search-ring)
+              (user-error "History is empty"))
+          :history t
+          :sort nil))
+   (setq isearch-new-message
+         (mapconcat 'isearch-text-char-description
+		    isearch-new-string ""))))
+
 ;;;;; Command: consult-minor-mode-menu
 
 (defun consult--minor-mode-candidates ()

--- a/consult.texi
+++ b/consult.texi
@@ -332,6 +332,13 @@ the @samp{command-history} command from chistory.el.
 @samp{consult-history}: Insert a string from the current buffer history.
 This command can be invoked from the minibuffer. In that case the
 history stored in the @samp{minibuffer-history-variable} is used.
+@item
+@samp{consult-isearch}: During an Isearch session, this command picks a
+search string from history. Outside of Isearch, it reads a string
+from the minibuffer and starts searching; this is useful, for
+instance, as an Embark action. (Note that Isearch does not normally
+read from the minibuffer. What you see at the bottom of the screen
+is the echo area!)
 @end itemize
 
 @node Major and minor modes
@@ -595,6 +602,14 @@ the box with the default completion, Icomplete and Selectrum.
          ("M-y" . consult-yank-pop)
          ("<help> a" . consult-apropos))
 
+  ;; Bind `consult-isearch' if desired.  The example below overloads
+  ;; it with `consult-history', so that you can access the search
+  ;; history with the same key, but only after starting Isearch.  Of
+  ;; course you can bind the command to a dedicated key in the global
+  ;; map instead.
+  :bind (:map isearch-mode-map
+         ("C-c h" . consult-isearch))
+
   ;; The :init configuration is always executed (Not lazy!)
   :init
 
@@ -648,6 +663,11 @@ the box with the default completion, Icomplete and Selectrum.
 (use-package consult-flycheck
   :bind (:map flycheck-command-map
               ("!" . consult-flycheck)))
+
+;; Optionally integrate `consult-isearch' with Embark.
+(use-package embark
+  :bind (:map embark-general-map
+         ("C-s" . consult-isearch)))
 @end lisp
 
 @node Customizable variables


### PR DESCRIPTION
Do you think this is of broad enough interest? It's meant to be bound in `isearch-mode-map`.

I'm not sure if there's an useful completion category to report in this `consult--read`.