### PR TITLE
Add consult-register-load/save

### DIFF
--- a/README.org
+++ b/README.org
@@ -539,8 +539,12 @@ the box with the default completion, Icomplete and Selectrum.
    ;; Configure register preview function.
    ;; This gives a consistent display for both `consult-register' and
    ;; the register preview when editing registers.
+   ;; Hide mode-line of register preview window.
    (setq register-preview-delay 0
          register-preview-function #'consult-register-preview)
+   (add-to-list 'display-buffer-alist
+                '("\\`\\*Register Preview\\*"
+                  nil (window-parameters (mode-line-format . none))))
 
    ;; Configure other variables and modes in the :config section, after lazily loading the package
    :config

--- a/README.org
+++ b/README.org
@@ -140,8 +140,13 @@ variables and functions with their descriptions.
    command is useful to search the register contents. For quick access it is
    recommended to use =consult-register-load= or =consult-register-store= or the
    built-in Emacs register commands.
- - =consult-register-load=, =consult-register-store=: Utility functions to quickly
-   load a register or save to a register in a dwim fashion.
+ - =consult-register-load=: Utility command to quickly load a register.
+   The command either jumps to the register value or inserts it.
+ - =consult-register-store=: Improved UI to store registers depending on the current
+   context with an action menu. With a numeric prefix, store/add the number. With an
+   active region, store/append/prepend the contents, optionally deleting the region
+   when a prefx argument is given. Otherwise store point, frameset, window or
+   kmacro.
  - =consult-register-preview=: Supplementary function which can be
    used as =register-preview-function= for a consistent display. See the [[#example-configuration][example
    configuration]] for how the =consult-register-preview= function is meant to be
@@ -621,6 +626,7 @@ the box with the default completion, Icomplete and Selectrum.
  | consult-preview-max-size        | 10485760           | Size limit for previewed files                           |
  | consult-project-root-function   | nil                | Function which returns current project root              |
  | consult-register-narrow         | ...                | Narrowing configuration for =consult-register=           |
+ | consult-register-store-hook     | ...                | Register store actions for =consult-register-store=      |
  | consult-ripgrep-command         | '(...)             | Command line arguments for ripgrep                       |
  | consult-themes                  | nil                | List of themes to be presented for selection             |
  | consult-view-list-function      | nil                | Function which returns a list of view names as strings   |

--- a/README.org
+++ b/README.org
@@ -118,22 +118,34 @@ variables and functions with their descriptions.
  :end:
  #+cindex: editing
 
- #+findex: consult-register
- #+findex: consult-register-preview
  #+findex: consult-yank
  #+findex: consult-kmacro
- - =consult-register=: Select from list of registers. The command
-   supports narrowing to register types and preview of marker positions. This
-   command is useful to search the register contents. For quick access it is
-   recommended to use the built-in Emacs commands like =jump-to-register=. There
-   is also the supplementary function =consult-register-preview= which can be
-   used as =register-preview-function= for a consistent display. See the [[#example-configuration][example
-   configuration]] for how the =consult-register-preview= function is meant to be
-   used.
  - =consult-yank=, =consult-yank-pop=: Enhanced version of =yank= and
    =yank-pop= which allows selecting from the kill-ring. Live preview is
    supported when selecting from the kill-ring.
  - =consult-kmacro=: Select macro from the macro ring and execute it.
+
+** Register
+ :properties:
+ :description: Searching through registers and fast access
+ :end:
+ #+cindex: register
+
+ #+findex: consult-register
+ #+findex: consult-register-load
+ #+findex: consult-register-save
+ #+findex: consult-register-preview
+ - =consult-register=: Select from list of registers. The command
+   supports narrowing to register types and preview of marker positions. This
+   command is useful to search the register contents. For quick access it is
+   recommended to use =consult-register-load= or =consult-register-save= or the
+   built-in Emacs register commands.
+ - =consult-register-load=, =consult-register-save=: Utility functions to quickly
+   load a register or save to a register in a dwim fashion.
+ - =consult-register-preview=: Supplementary function which can be
+   used as =register-preview-function= for a consistent display. See the [[#example-configuration][example
+   configuration]] for how the =consult-register-preview= function is meant to be
+   used.
 
 ** Navigation
  :properties:
@@ -483,13 +495,16 @@ the box with the default completion, Icomplete and Selectrum.
    :bind (;; C-c bindings (mode-specific-map)
           ("C-c h" . consult-history)
           ("C-c m" . consult-mode-command)
+          ("C-c b" . consult-bookmark)
           ;; C-x bindings (ctl-x-map)
           ("C-x M-:" . consult-complex-command)
           ("C-x b" . consult-buffer)
           ("C-x 4 b" . consult-buffer-other-window)
           ("C-x 5 b" . consult-buffer-other-frame)
-          ("C-x r x" . consult-register)
-          ("C-x r b" . consult-bookmark)
+          ;; Custom M-# bindings for fast register access
+          ("M-#" . consult-register-load)
+          ("M-'" . consult-register-save)
+          ("C-M-#" . consult-register)
           ;; M-g bindings (goto-map)
           ("M-g g" . consult-goto-line)
           ("M-g M-g" . consult-goto-line)

--- a/README.org
+++ b/README.org
@@ -631,7 +631,6 @@ the box with the default completion, Icomplete and Selectrum.
  | consult-preview-max-size        | 10485760           | Size limit for previewed files                           |
  | consult-project-root-function   | nil                | Function which returns current project root              |
  | consult-register-narrow         | ...                | Narrowing configuration for =consult-register=           |
- | consult-register-store-hook     | ...                | Register store actions for =consult-register-store=      |
  | consult-ripgrep-command         | '(...)             | Command line arguments for ripgrep                       |
  | consult-themes                  | nil                | List of themes to be presented for selection             |
  | consult-view-list-function      | nil                | Function which returns a list of view names as strings   |

--- a/README.org
+++ b/README.org
@@ -544,12 +544,17 @@ the box with the default completion, Icomplete and Selectrum.
    ;; Configure register preview function.
    ;; This gives a consistent display for both `consult-register' and
    ;; the register preview when editing registers.
-   ;; Hide mode-line of register preview window.
    (setq register-preview-delay 0
          register-preview-function #'consult-register-preview)
+   ;; Optionally hide mode-line of register preview window.
    (add-to-list 'display-buffer-alist
                 '("\\`\\*Register Preview\\*"
                   nil (window-parameters (mode-line-format . none))))
+   ;; Optionally sort registers in preview window.
+   (advice-add #'register-preview :around
+               (lambda (fun &rest args)
+                 (let ((register-alist (seq-sort #'car-less-than-car register-alist)))
+                   (apply fun args))))
 
    ;; Configure other variables and modes in the :config section, after lazily loading the package
    :config

--- a/README.org
+++ b/README.org
@@ -133,14 +133,14 @@ variables and functions with their descriptions.
 
  #+findex: consult-register
  #+findex: consult-register-load
- #+findex: consult-register-save
+ #+findex: consult-register-store
  #+findex: consult-register-preview
  - =consult-register=: Select from list of registers. The command
    supports narrowing to register types and preview of marker positions. This
    command is useful to search the register contents. For quick access it is
-   recommended to use =consult-register-load= or =consult-register-save= or the
+   recommended to use =consult-register-load= or =consult-register-store= or the
    built-in Emacs register commands.
- - =consult-register-load=, =consult-register-save=: Utility functions to quickly
+ - =consult-register-load=, =consult-register-store=: Utility functions to quickly
    load a register or save to a register in a dwim fashion.
  - =consult-register-preview=: Supplementary function which can be
    used as =register-preview-function= for a consistent display. See the [[#example-configuration][example
@@ -503,7 +503,7 @@ the box with the default completion, Icomplete and Selectrum.
           ("C-x 5 b" . consult-buffer-other-frame)
           ;; Custom M-# bindings for fast register access
           ("M-#" . consult-register-load)
-          ("M-'" . consult-register-save)
+          ("M-'" . consult-register-store)
           ("C-M-#" . consult-register)
           ;; M-g bindings (goto-map)
           ("M-g g" . consult-goto-line)

--- a/consult.el
+++ b/consult.el
@@ -2337,9 +2337,12 @@ number. With ARG store the frame configuration. Otherwise, store the point."
   (interactive (list (register-read-with-preview
                       (cond
                        ((use-region-p)
-                        (if (consp current-prefix-arg)
-                            "Append region to register: "
-                          "Store region in register: "))
+                        (cond
+                         ((or (equal current-prefix-arg '(16))
+                              (equal current-prefix-arg '(-16)))
+                          "Prepend region to register: ")
+                         (current-prefix-arg "Append region to register: ")
+                         (t "Store region in register: ")))
                        ((numberp current-prefix-arg)
                         (format "Store %s in register: " current-prefix-arg))
                        ((equal current-prefix-arg '(16)) "Store frameset in register: ")
@@ -2350,10 +2353,12 @@ number. With ARG store the frame configuration. Otherwise, store the point."
    ((use-region-p)
     (let ((beg (region-beginning))
           (end (region-end))
-          (del (or (equal arg '-)  (equal arg '(-4)))))
-      (if (consp arg)
-          (append-to-register reg beg end del)
-        (copy-to-register reg beg end del t))))
+          (del (or (equal arg '-) (equal arg '(-4)) (equal arg '(-16)))))
+      (cond
+       ((or (equal arg '(16)) (equal arg '(-16)))
+        (prepend-to-register reg beg end del))
+       (arg (append-to-register reg beg end del))
+       (t (copy-to-register reg beg end del t)))))
    ((numberp arg) (number-to-register arg reg))
    ((equal arg '(16)) (frameset-to-register reg))
    (arg (window-configuration-to-register reg))

--- a/consult.el
+++ b/consult.el
@@ -2295,7 +2295,7 @@ registers it is still recommended to use the register functions
 register access functions. The command supports narrowing, see
 `consult-register-narrow'. Marker positions are previewed. See
 `jump-to-register' and `insert-register' for the meaning of ARG."
-  (interactive "p")
+  (interactive "P")
   (consult-register-load
    (consult--read
     "Register: "
@@ -2367,6 +2367,23 @@ meaning of ARG."
   (condition-case nil
       (jump-to-register reg arg)
     (user-error (insert-register reg arg))))
+
+(defun consult-register-access (arg)
+  (interactive "P")
+  (let ((reg)
+        (store)
+        (register-preview-delay 0)
+        (ev last-input-event))
+    (while (not reg)
+      (condition-case nil
+          (setq reg (register-read-with-preview (if store "Overwrite register: " "Register: ")))
+        (error
+         (unless (eq last-input-event ev)
+           (error "Not a register key"))
+         (setq store (not store)))))
+    (if (or store (not (alist-get reg register-alist)))
+        (consult-register-save reg arg)
+      (consult-register-load reg arg))))
 
 ;;;;; Command: consult-bookmark
 

--- a/consult.el
+++ b/consult.el
@@ -2342,6 +2342,7 @@ number. With ARG store the frame configuration. Otherwise, store the point."
                           "Store region in register: "))
                        ((numberp current-prefix-arg)
                         (format "Store %s in register: " current-prefix-arg))
+                       (current-prefix-arg "Store window in register: ")
                        (t "Store point in register: ")))
                      current-prefix-arg))
   (cond
@@ -2353,7 +2354,8 @@ number. With ARG store the frame configuration. Otherwise, store the point."
           (append-to-register reg beg end del)
         (copy-to-register reg beg end del t))))
    ((numberp arg) (number-to-register arg reg))
-   (t (point-to-register reg arg))))
+   (arg (window-configuration-to-register reg))
+   (t (point-to-register reg))))
 
 ;;;###autoload
 (defun consult-register-load (reg &optional arg)

--- a/consult.el
+++ b/consult.el
@@ -2291,7 +2291,7 @@ This function can be used as `register-preview-function'."
 
 This command is useful to search the register contents. For quick access to
 registers it is still recommended to use the register functions
-`consult-register-load' and `consult-register-save' or the built-in built-in
+`consult-register-load' and `consult-register-store' or the built-in built-in
 register access functions. The command supports narrowing, see
 `consult-register-narrow'. Marker positions are previewed. See
 `jump-to-register' and `insert-register' for the meaning of ARG."
@@ -2328,7 +2328,7 @@ register access functions. The command supports narrowing, see
    arg))
 
 ;;;###autoload
-(defun consult-register-save (reg &optional arg)
+(defun consult-register-store (reg &optional arg)
   "Store what I mean in a REG.
 
 With an active region, store or append (with ARG) the contents, optionally
@@ -2382,7 +2382,7 @@ meaning of ARG."
            (error "Not a register key"))
          (setq store (not store)))))
     (if (or store (not (alist-get reg register-alist)))
-        (consult-register-save reg arg)
+        (consult-register-store reg arg)
       (consult-register-load reg arg))))
 
 ;;;;; Command: consult-bookmark

--- a/consult.el
+++ b/consult.el
@@ -2342,6 +2342,7 @@ number. With ARG store the frame configuration. Otherwise, store the point."
                           "Store region in register: "))
                        ((numberp current-prefix-arg)
                         (format "Store %s in register: " current-prefix-arg))
+                       ((equal current-prefix-arg '(16)) "Store frameset in register: ")
                        (current-prefix-arg "Store window in register: ")
                        (t "Store point in register: ")))
                      current-prefix-arg))
@@ -2354,6 +2355,7 @@ number. With ARG store the frame configuration. Otherwise, store the point."
           (append-to-register reg beg end del)
         (copy-to-register reg beg end del t))))
    ((numberp arg) (number-to-register arg reg))
+   ((equal arg '(16)) (frameset-to-register reg))
    (arg (window-configuration-to-register reg))
    (t (point-to-register reg))))
 

--- a/consult.texi
+++ b/consult.texi
@@ -797,9 +797,6 @@ an overview of all Consult variables and functions with their descriptions.
 @item consult-register-narrow
 @tab @dots{}
 @tab Narrowing configuration for @samp{consult-register}
-@item consult-register-store-hook
-@tab @dots{}
-@tab Register store actions for @samp{consult-register-store}
 @item consult-ripgrep-command
 @tab '(@dots{})
 @tab Command line arguments for ripgrep

--- a/consult.texi
+++ b/consult.texi
@@ -655,12 +655,17 @@ the box with the default completion, Icomplete and Selectrum.
   ;; Configure register preview function.
   ;; This gives a consistent display for both `consult-register' and
   ;; the register preview when editing registers.
-  ;; Hide mode-line of register preview window.
   (setq register-preview-delay 0
         register-preview-function #'consult-register-preview)
+  ;; Optionally hide mode-line of register preview window.
   (add-to-list 'display-buffer-alist
                '("\\`\\*Register Preview\\*"
                  nil (window-parameters (mode-line-format . none))))
+  ;; Optionally sort registers in preview window.
+  (advice-add #'register-preview :around
+              (lambda (fun &rest args)
+                (let ((register-alist (seq-sort #'car-less-than-car register-alist)))
+                  (apply fun args))))
 
   ;; Configure other variables and modes in the :config section, after lazily loading the package
   :config

--- a/consult.texi
+++ b/consult.texi
@@ -649,8 +649,12 @@ the box with the default completion, Icomplete and Selectrum.
   ;; Configure register preview function.
   ;; This gives a consistent display for both `consult-register' and
   ;; the register preview when editing registers.
+  ;; Hide mode-line of register preview window.
   (setq register-preview-delay 0
         register-preview-function #'consult-register-preview)
+  (add-to-list 'display-buffer-alist
+               '("\\`\\*Register Preview\\*"
+                 nil (window-parameters (mode-line-format . none))))
 
   ;; Configure other variables and modes in the :config section, after lazily loading the package
   :config

--- a/consult.texi
+++ b/consult.texi
@@ -39,6 +39,7 @@ Available commands
 
 * Virtual Buffers::              Buffers, bookmarks and recent files
 * Editing::                      Commands useful for editing
+* Register::                     Searching through registers and fast access
 * Navigation::                   Mark rings, outlines and imenu
 * Search::                       Line search, grep and file search
 * Grep and Find::                Searching through the filesystem
@@ -115,6 +116,7 @@ variables and functions with their descriptions.
 @menu
 * Virtual Buffers::              Buffers, bookmarks and recent files
 * Editing::                      Commands useful for editing
+* Register::                     Searching through registers and fast access
 * Navigation::                   Mark rings, outlines and imenu
 * Search::                       Line search, grep and file search
 * Grep and Find::                Searching through the filesystem
@@ -174,26 +176,41 @@ instead, which includes recent files.
 
 @cindex editing
 
-@findex consult-register
-@findex consult-register-preview
 @findex consult-yank
 @findex consult-kmacro
 @itemize
-@item
-@samp{consult-register}: Select from list of registers. The command
-supports narrowing to register types and preview of marker positions. This
-command is useful to search the register contents. For quick access it is
-recommended to use the built-in Emacs commands like @samp{jump-to-register}. There
-is also the supplementary function @samp{consult-register-preview} which can be
-used as @samp{register-preview-function} for a consistent display. See the @ref{Example configuration, , example
-configuration} for how the @samp{consult-register-preview} function is meant to be
-used.
 @item
 @samp{consult-yank}, @samp{consult-yank-pop}: Enhanced version of @samp{yank} and
 @samp{yank-pop} which allows selecting from the kill-ring. Live preview is
 supported when selecting from the kill-ring.
 @item
 @samp{consult-kmacro}: Select macro from the macro ring and execute it.
+@end itemize
+
+@node Register
+@section Register
+
+@cindex register
+
+@findex consult-register
+@findex consult-register-load
+@findex consult-register-save
+@findex consult-register-preview
+@itemize
+@item
+@samp{consult-register}: Select from list of registers. The command
+supports narrowing to register types and preview of marker positions. This
+command is useful to search the register contents. For quick access it is
+recommended to use @samp{consult-register-load} or @samp{consult-register-save} or the
+built-in Emacs register commands.
+@item
+@samp{consult-register-load}, @samp{consult-register-save}: Utility functions to quickly
+load a register or save to a register in a dwim fashion.
+@item
+@samp{consult-register-preview}: Supplementary function which can be
+used as @samp{register-preview-function} for a consistent display. See the @ref{Example configuration, , example
+configuration} for how the @samp{consult-register-preview} function is meant to be
+used.
 @end itemize
 
 @node Navigation
@@ -588,13 +605,16 @@ the box with the default completion, Icomplete and Selectrum.
   :bind (;; C-c bindings (mode-specific-map)
          ("C-c h" . consult-history)
          ("C-c m" . consult-mode-command)
+         ("C-c b" . consult-bookmark)
          ;; C-x bindings (ctl-x-map)
          ("C-x M-:" . consult-complex-command)
          ("C-x b" . consult-buffer)
          ("C-x 4 b" . consult-buffer-other-window)
          ("C-x 5 b" . consult-buffer-other-frame)
-         ("C-x r x" . consult-register)
-         ("C-x r b" . consult-bookmark)
+         ;; Custom M-# bindings for fast register access
+         ("M-#" . consult-register-load)
+         ("M-'" . consult-register-save)
+         ("C-M-#" . consult-register)
          ;; M-g bindings (goto-map)
          ("M-g g" . consult-goto-line)
          ("M-g M-g" . consult-goto-line)

--- a/consult.texi
+++ b/consult.texi
@@ -204,8 +204,14 @@ command is useful to search the register contents. For quick access it is
 recommended to use @samp{consult-register-load} or @samp{consult-register-store} or the
 built-in Emacs register commands.
 @item
-@samp{consult-register-load}, @samp{consult-register-store}: Utility functions to quickly
-load a register or save to a register in a dwim fashion.
+@samp{consult-register-load}: Utility command to quickly load a register.
+The command either jumps to the register value or inserts it.
+@item
+@samp{consult-register-store}: Improved UI to store registers depending on the current
+context with an action menu. With a numeric prefix, store/add the number. With an
+active region, store/append/prepend the contents, optionally deleting the region
+when a prefx argument is given. Otherwise store point, frameset, window or
+kmacro.
 @item
 @samp{consult-register-preview}: Supplementary function which can be
 used as @samp{register-preview-function} for a consistent display. See the @ref{Example configuration, , example
@@ -786,6 +792,9 @@ an overview of all Consult variables and functions with their descriptions.
 @item consult-register-narrow
 @tab @dots{}
 @tab Narrowing configuration for @samp{consult-register}
+@item consult-register-store-hook
+@tab @dots{}
+@tab Register store actions for @samp{consult-register-store}
 @item consult-ripgrep-command
 @tab '(@dots{})
 @tab Command line arguments for ripgrep

--- a/consult.texi
+++ b/consult.texi
@@ -194,17 +194,17 @@ supported when selecting from the kill-ring.
 
 @findex consult-register
 @findex consult-register-load
-@findex consult-register-save
+@findex consult-register-store
 @findex consult-register-preview
 @itemize
 @item
 @samp{consult-register}: Select from list of registers. The command
 supports narrowing to register types and preview of marker positions. This
 command is useful to search the register contents. For quick access it is
-recommended to use @samp{consult-register-load} or @samp{consult-register-save} or the
+recommended to use @samp{consult-register-load} or @samp{consult-register-store} or the
 built-in Emacs register commands.
 @item
-@samp{consult-register-load}, @samp{consult-register-save}: Utility functions to quickly
+@samp{consult-register-load}, @samp{consult-register-store}: Utility functions to quickly
 load a register or save to a register in a dwim fashion.
 @item
 @samp{consult-register-preview}: Supplementary function which can be
@@ -613,7 +613,7 @@ the box with the default completion, Icomplete and Selectrum.
          ("C-x 5 b" . consult-buffer-other-frame)
          ;; Custom M-# bindings for fast register access
          ("M-#" . consult-register-load)
-         ("M-'" . consult-register-save)
+         ("M-'" . consult-register-store)
          ("C-M-#" . consult-register)
          ;; M-g bindings (goto-map)
          ("M-g g" . consult-goto-line)


### PR DESCRIPTION
@oantolin I saw you commenting on reddit about registers and it reminded me again that maybe something should be done about the register access functions. I quickly imported your utilities from your https://github.com/oantolin/emacs-config/blob/208755c715284f0457e852e777a38a463b1aefcb/my-lisp/text-extras.el. The functions are all in the consult-register namespace and could possibly go to a separate library. What do you think about having such functions here? Maybe it makes sense to *not* have these functions here since they are not related to completing read and are simple enough to keep around in the init.el. The load function can barely be criticized, I think it should be upstream in this form. The save function is more questionable since, as you said, it is rather ad-hoc. But arguably, saving strings, numbers and points are the most important use-cases for registers during editing.