### PR TITLE
Save window excursion when previewing

### DIFF
--- a/consult.el
+++ b/consult.el
@@ -919,7 +919,7 @@ See consult--with-preview for the arguments PREVIEW-KEY, PREVIEW, TRANSFORM and 
               (fset post-command-sym (lambda () (setq input (minibuffer-contents-no-properties))))
               (add-hook 'post-command-hook post-command-sym nil t))))
       (unwind-protect
-          (cons (setq selected (when-let (result (funcall fun))
+          (cons (setq selected (when-let (result (save-window-excursion (funcall fun)))
                                  (funcall transform input result)))
                 input)
         ;; If there is a preview function, always call restore!


### PR DESCRIPTION
When consult is used with selectrum and mini-frame (minibuffer in a child-frame), window changes due to previews are not reverted on abort (`C-g`).

Saving the window excursion while selecting a candidate appears to fix the issue and doesn't appear to introduce any other issues. However, I'm not 100% sure _why_ this is an issue with mini-frame, and not an issue without it, so I have no idea if this is the correct fix.