### PR TITLE
consult--async-command: Flush candidates when input is too short

### DIFF
--- a/consult.el
+++ b/consult.el
@@ -1140,8 +1140,10 @@ The DEBOUNCE delay defaults to `consult-async-input-debounce'."
          (when debounce-timer
            (cancel-timer debounce-timer))
          (unless (string= action input)
-           (funcall async (setq input "")) ;; cancel running process
-           (unless (string= action "")
+           (setq input "")
+           (if (string= action "")
+               (funcall async 'flush)
+             (funcall async input) ;; cancel running process
              (setq debounce-timer (run-at-time
                                    (+ debounce (if unlocked 0 throttle)) nil
                                    (lambda () (funcall async (setq unlocked nil input action))))))))


### PR DESCRIPTION
When entering a not long enough input after getting some candidates, the candidate list was not being flushed so it was displaying a result from a previous input.
For example:
- Execute `consult-grep`
- Enter `#de`
  - No candidates because the input is too short
- Enter `#def`
  - Get candidates
- Remove the whole input
  - The candidates don't update and still show **def** to be matching
- Enter an input with no matches, like `#XX`
  - The candidates don't update and still show **def** to be matching

This pr prevents this bug, flushing the candidate list whenever the input is not long enough.