### PR TITLE
consult-isearch: remove unnecessary line

### DIFF
--- a/consult.el
+++ b/consult.el
@@ -2651,7 +2651,6 @@ starts a new Isearch session otherwise."
                   (?r . "Regexp")
                   (?s . "Symbol")
                   (?w . "Word"))))
-    (unless isearch-mode (isearch-mode t))
     (with-isearch-suspended
      (setq isearch-new-string
            (consult--read


### PR DESCRIPTION
`with-suspended-isearch` actually starts a new Isearch if applicable.