### PR TITLE
Better fix for the async filtering issue reported by @clemera

### DIFF
--- a/consult-selectrum.el
+++ b/consult-selectrum.el
@@ -72,10 +72,15 @@ See `consult--read' for the CANDIDATES and DEFAULT-TOP arguments."
 
 (defun consult-selectrum--async-split-setup ()
   "Advice for `consult--async-split-setup' to be used by Selectrum."
-  (setq-local selectrum-refine-candidates-function
-              (consult-selectrum--async-split-wrap selectrum-refine-candidates-function))
-  (setq-local selectrum-highlight-candidates-function
-              (consult-selectrum--async-split-wrap selectrum-highlight-candidates-function)))
+  ;; Only overwrite the Selectrum refine/highlight functions if Selectrum does not use the completion-style
+  (unless (eq selectrum-refine-candidates-function
+              'selectrum-refine-candidates-using-completions-styles)
+    (setq-local selectrum-refine-candidates-function
+                (consult-selectrum--async-split-wrap selectrum-refine-candidates-function)))
+  (unless (eq selectrum-highlight-candidates-function
+              'selectrum-candidates-identity)
+    (setq-local selectrum-highlight-candidates-function
+                (consult-selectrum--async-split-wrap selectrum-highlight-candidates-function))))
 
 (add-hook 'consult--completion-filter-hook #'consult-selectrum--filter)
 (add-hook 'consult--completion-candidate-hook #'consult-selectrum--candidate)


### PR DESCRIPTION
See 0c9d6ab4fadfc3613880148bc1ed2c53cd851fbe

@clemera Can you please give it another quick test? It should work with the current Selectrum independent of selectrum-active-p. It seems to work for me in both cases, if the completion style is used by Selectrum and if it is not.