### PR TITLE
Fix broken match beginning/end when splitting OPTS

### DIFF
--- a/consult.el
+++ b/consult.el
@@ -1334,9 +1334,11 @@ The refresh happens after a DELAY, defaulting to `consult-async-refresh-delay'."
     (save-match-data
       (let ((opts))
         (when (string-match " +--\\( +\\|$\\)" input)
-          ;; split-string-and-unquote fails if the quotes are invalid. Ignore it.
-          (setq opts (ignore-errors (split-string-and-unquote (substring input (match-end 0))))
-                input (substring input 0 (match-beginning 0))))
+          (let ((beg (match-beginning 0))
+                (end (match-end 0)))
+            ;; split-string-and-unquote fails if the quotes are invalid. Ignore it.
+            (setq opts (ignore-errors (split-string-and-unquote (substring input end)))
+                  input (substring input 0 beg))))
         (mapcan (lambda (x)
                   (if (string= x "OPTS")
                       opts


### PR DESCRIPTION
When `string-match` is used to determine whether we have OPTS or not, `(match-beginning 0)` and `(match-end 0)` are used to mark the split portion, get rid of the double dash and `substring` out the ARGS (i.e. `input`) and the OPTS (i.e. `opts`)

However, the subsequent call to `split-string-and-unquote` when setting `opts` **contains an inner call to `string-match`**, which clobbers the previous `(match-beginning 0)` value used to extract the `input`. For me, this resulted in the input being truncated to just 2 characters whenever there were OPTS provided. For example, when entering the input "foo -- -g *.el", the ARGS would just be "fo".

To fix this, just use a `let` to close over and remember the relevant match beginning and end values before they're overridden by `split-string-and-unquote`. 

I'm hoping this fix is good enough? It does seem to behave nicely for all the use cases I've personally tested.