### PR TITLE
consult-register-format: Do not truncate strings

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,5 +1,6 @@
 * Main
 
+- consult-register-format: Do not truncate register strings.
 - Multi sources/consult-buffer: Ensure that original buffer is
   shown, when the currently selected source does not perform preview.
 - Add consult-preview-raw-size

--- a/consult.el
+++ b/consult.el
@@ -2530,6 +2530,7 @@ SHOW-EMPTY must be t if the window should be shown for an empty register list."
         (setq-local cursor-in-non-selected-windows nil)
         (setq-local mode-line-format nil)
         (setq-local window-min-height 1)
+        (setq-local truncate-lines t)
         (seq-do-indexed
          (lambda (reg idx)
            (let ((beg (point)))
@@ -2543,9 +2544,7 @@ SHOW-EMPTY must be t if the window should be shown for an empty register list."
   "Enhanced preview of register REG.
 
 This function can be used as `register-preview-function'."
-  (apply #'concat
-         (mapcar (lambda (s) (concat (truncate-string-to-width s 100 0 nil "…") "\n"))
-                 (split-string (consult--register-format reg) "\n"))))
+  (concat (consult--register-format reg) "\n"))
 
 (defun consult--register-format (reg)
   "Format register REG for preview."


### PR DESCRIPTION
@oantolin I just saw your commit, https://github.com/oantolin/emacs-config/commit/30443cc11078a2d5e8d3753efe95629461413b92. Do you think it makes sense to make this truncation behavior the default? I think I only truncated the register string because the original function does it. In our case showing the full string makes more sense and is more consistent with the consult-register ui, which does not truncate.