### PR TITLE
Add previews to consult-completion-in-region

### DIFF
--- a/consult.el
+++ b/consult.el
@@ -3675,8 +3675,11 @@ See `consult-grep' for more details regarding the asynchronous search."
                            minibuffer-completion-table
                            minibuffer-completion-predicate)
           content
-        ;; Return the first candidate of the sorted completion list.
-        (car (completion-all-sorted-completions))))))
+        ;; Return the full first candidate of the sorted completion list.
+        (when-let ((completions (completion-all-sorted-completions)))
+          (concat
+           (substring content 0 (or (cdr (last completions)) 0))
+           (car completions)))))))
 
 (defun consult--default-completion-filter (category _highlight)
   "Return default filter function given the completion CATEGORY.

--- a/consult.el
+++ b/consult.el
@@ -2339,7 +2339,10 @@ The arguments and expected return value are as specified for
                     (absolute (file-name-absolute-p initial)))
                 (car
                  (consult--with-preview
-                     consult-preview-key
+                     (or (alist-get :preview-key
+                                    (alist-get 'consult-completion-in-region
+                                               consult-config))
+                         consult-preview-key)
                      (consult--region-state
                       start end 'consult-preview-completion-in-region)
                      (lambda (_input cand)


### PR DESCRIPTION
This adds previews to `consult-completion-in-region`. The preview code was removed from `consult--yank-read`, put into a little `consult--region-state` function and then used both in `consult--yank-read` and `consult-completion-in-region`.

(I ran into a small snag: `consult--read` cannot be passed a completion table function, because it expects functions to be async collections. I think I have a good workaround for that.)