### PR TITLE
Match prefix argument handling of insert-register

### DIFF
--- a/consult.el
+++ b/consult.el
@@ -2662,7 +2662,7 @@ meaning of prefix ARG."
     current-prefix-arg))
   (condition-case nil
       (jump-to-register reg arg)
-    (user-error (insert-register reg arg))))
+    (user-error (insert-register reg (not arg)))))
 
 (defun consult--register-action (action-list)
   "Read register key and execute action from ACTION-LIST.


### PR DESCRIPTION
consult-register-load was using the opposite convention than
insert-register. Without a prefix argument, consult-register-load
leaves point before the inserted text, and with a prefix argument,
after; insert-register does the opposite. This simple change aligns
the two.

The discrepancy happened because jump-register and insert-register
commands use different conventions for translating the prefix argument
to their second function argument: jump-register uses the arg,
insert-register uses (not arg).