### PR TITLE
consult-line: Quit isearch if applicable

### DIFF
--- a/consult.el
+++ b/consult.el
@@ -2051,7 +2051,8 @@ The symbol at point and the last `isearch-string' is added to the future history
      :lookup #'consult--line-match
      :default (car candidates)
      ;; Add isearch-string as initial input if starting from isearch
-     :initial (or initial (and isearch-mode isearch-string))
+     :initial (or initial
+                  (and isearch-mode (prog1 isearch-string (isearch-done))))
      :state (consult--jump-state))))
 
 ;;;;; Command: consult-keep-lines


### PR DESCRIPTION
Currently Isearch is still on after finishing `consult-line` when it is invoked from isearch. I've also noticed some key conflicts between isearch and the minibuffer in my setup.

The argument to `isearch-done` makes the current search string not be saved in the isearch history. Feel free to remove it if you think saving is better.