### PR TITLE
Abbreviate names of recent files in consult--source-file

### DIFF
--- a/consult.el
+++ b/consult.el
@@ -3286,7 +3286,8 @@ The command supports previewing the currently selected theme."
     :items
     ,(lambda ()
        (let ((ht (consult--cached-buffer-file-hash)))
-         (seq-remove (lambda (x) (gethash x ht)) recentf-list))))
+         (mapcar #'abbreviate-file-name
+                 (seq-remove (lambda (x) (gethash x ht)) recentf-list)))))
   "Recent file candidate source for `consult-buffer'.")
 
 ;;;###autoload


### PR DESCRIPTION
This is just a cosmetic improvement, to have shorter paths displayed for recent file candidates in consult buffer. Note that consult-recent-file already abbreviates file names.