### PR TITLE
Don't preview completion in region if its in the minibuffer

### DIFF
--- a/consult.el
+++ b/consult.el
@@ -2404,10 +2404,11 @@ The arguments and expected return value are as specified for
                         (absolute (file-name-absolute-p initial)))
                     (car
                      (consult--with-preview
-                         (or (alist-get :preview-key
-                                        (alist-get 'consult-completion-in-region
-                                                   consult-config))
-                             consult-preview-key)
+                         (unless (minibufferp)
+                           (or (alist-get :preview-key
+                                          (alist-get 'consult-completion-in-region
+                                                     consult-config))
+                               consult-preview-key))
                          (consult--region-preview
                           start end 'consult-preview-region)
                          (lambda (_input cand)


### PR DESCRIPTION
It doesn't work to show previews for completion in the minibuffer, since we prompt for a completion in a recursive minibuffer obscuring the one where we would be showing the previews.