### PR TITLE
consult-outline: Only fontify candidate lines

### DIFF
--- a/consult.el
+++ b/consult.el
@@ -886,10 +886,15 @@ Since the line number is part of the candidate it will be matched-on during comp
                str))
             candidates)))
 
-(defsubst consult--buffer-substring (beg end)
-  "Return buffer substring between BEG and END."
+(defsubst consult--buffer-substring (beg end &optional fontifyp)
+  "Return buffer substring between BEG and END.
+If FONTIFYP and `consult-fontify-preserve' are non-nil, first ensure that the
+region has been fontified."
   (if consult-fontify-preserve
-      (buffer-substring beg end)
+      (progn
+        (when fontifyp
+          (consult--fontify-region beg end))
+        (buffer-substring beg end))
     (buffer-substring-no-properties beg end)))
 
 (defun consult--region-with-cursor (begin end marker)
@@ -1927,7 +1932,6 @@ See `multi-occur' for the meaning of the arguments BUFS, REGEXP and NLINES."
 (defun consult--outline-candidates ()
   "Return alist of outline headings and positions."
   (consult--forbid-minibuffer)
-  (consult--fontify-all)
   (let* ((line (line-number-at-pos (point-min) consult-line-numbers-widen))
          (heading-regexp (concat "^\\(?:"
                                  (if (boundp 'outline-regexp)
@@ -1940,7 +1944,7 @@ See `multi-occur' for the meaning of the arguments BUFS, REGEXP and NLINES."
       (while (save-excursion (re-search-forward heading-regexp nil t))
         (setq line (+ line (consult--count-lines (match-beginning 0))))
         (push (list (point-marker) line
-                    (consult--buffer-substring (line-beginning-position) (line-end-position)))
+                    (consult--buffer-substring (line-beginning-position) (line-end-position) t))
               candidates)
         (unless (eobp) (forward-char 1))))
     (unless candidates


### PR DESCRIPTION
Instead of fontifying the entire buffer, only fontify candidates. This can greatly improve the speed of the first invocation in large buffers. It also allows getting fontification even in buffers larger than consult-fontify-max-size.

Let me know if this is okay. It seems to work well for me in testing. It is instant for me on the first run in files where the previous run took 6 seconds and in files bigger than `consult-fontify-max-size`. I'm not sure there would be a case where there would be enough headings to slow things down as much as `consult-line` in a buffer close to `consult-fontify-max-size` (it seems unlikely), but if there is a limit, I think it should be a separate variable. Let me know what you think.