### PR TITLE
consult-agenda and consult-clock-in

### DIFF
--- a/README.org
+++ b/README.org
@@ -313,7 +313,6 @@ variables and functions with their descriptions.
    :description: Org-specific commands
    :end:
 
- #+findex: consult-org-clock-in
  #+findex: consult-org-heading
  #+findex: consult-org-agenda
  - =consult-org-heading=: Similar to =consult-outline=, for Org
@@ -322,8 +321,6 @@ variables and functions with their descriptions.
  - =consult-org-agenda=: Jump to an agenda heading. Supports
    narrowing by heading level, priority and TODO state, as well as
    live preview and recursive editing.
- - =consult-org-clock-in=: Select a task and clock into it. Supports
-   narrowing by heading level, priority and TODO state.
 
 ** Miscellaneous
    :properties:

--- a/README.org
+++ b/README.org
@@ -168,6 +168,8 @@ variables and functions with their descriptions.
  #+findex: consult-outline
  #+findex: consult-imenu
  #+findex: consult-project-imenu
+ #+findex: consult-org-heading
+ #+findex: consult-org-agenda
  - =consult-goto-line=: Jump to line number enhanced with live preview.
    This is a drop-in replacement for =goto-line=.
  - =consult-mark=: Jump to a marker in the =mark-ring=. Supports live
@@ -182,6 +184,12 @@ variables and functions with their descriptions.
    the same major mode as the current buffer. Supports live preview,
    recursive editing and narrowing. This feature has been inspired by
    [[https://github.com/vspinu/imenu-anywhere][imenu-anywhere]].
+ - =consult-org-heading=: Similar to =consult-outline=, for Org
+   buffers. Supports narrowing by heading level, priority and TODO
+   state, as well as live preview and recursive editing.
+ - =consult-org-agenda=: Jump to an agenda heading. Supports
+   narrowing by heading level, priority and TODO state, as well as
+   live preview and recursive editing.
 
 ** Search
    :properties:
@@ -319,6 +327,7 @@ variables and functions with their descriptions.
  #+findex: consult-theme
  #+findex: consult-man
  #+findex: consult-xref
+ #+findex: consult-org-clock-in
  - =consult-apropos=: Replacement for =apropos= with completion.
  - =consult-man=: Find Unix man page, via Unix =apropos= or =man -k=.
    The selected man page is opened using the Emacs =man= command.
@@ -338,6 +347,8 @@ variables and functions with their descriptions.
    candidates.
  - =consult-xref=: Integration with xref. This function can be set as
    as =xref-show-xrefs-function= and =xref-show-definitions-function=.
+ - =consult-org-clock-in=: Select a task and clock into it. Supports
+   narrowing by heading level, priority and TODO state.
 
 * Special features
   :properties:

--- a/README.org
+++ b/README.org
@@ -168,8 +168,6 @@ variables and functions with their descriptions.
  #+findex: consult-outline
  #+findex: consult-imenu
  #+findex: consult-project-imenu
- #+findex: consult-org-heading
- #+findex: consult-org-agenda
  - =consult-goto-line=: Jump to line number enhanced with live preview.
    This is a drop-in replacement for =goto-line=.
  - =consult-mark=: Jump to a marker in the =mark-ring=. Supports live
@@ -184,12 +182,6 @@ variables and functions with their descriptions.
    the same major mode as the current buffer. Supports live preview,
    recursive editing and narrowing. This feature has been inspired by
    [[https://github.com/vspinu/imenu-anywhere][imenu-anywhere]].
- - =consult-org-heading=: Similar to =consult-outline=, for Org
-   buffers. Supports narrowing by heading level, priority and TODO
-   state, as well as live preview and recursive editing.
- - =consult-org-agenda=: Jump to an agenda heading. Supports
-   narrowing by heading level, priority and TODO state, as well as
-   live preview and recursive editing.
 
 ** Search
    :properties:
@@ -316,6 +308,23 @@ variables and functions with their descriptions.
    or major modes. Supports narrowing to local-minor/global-minor/major
    mode via the keys =l/g/m=.
 
+** Org Mode
+   :properties:
+   :description: Org-specific commands
+   :end:
+
+ #+findex: consult-org-clock-in
+ #+findex: consult-org-heading
+ #+findex: consult-org-agenda
+ - =consult-org-heading=: Similar to =consult-outline=, for Org
+   buffers. Supports narrowing by heading level, priority and TODO
+   state, as well as live preview and recursive editing.
+ - =consult-org-agenda=: Jump to an agenda heading. Supports
+   narrowing by heading level, priority and TODO state, as well as
+   live preview and recursive editing.
+ - =consult-org-clock-in=: Select a task and clock into it. Supports
+   narrowing by heading level, priority and TODO state.
+
 ** Miscellaneous
    :properties:
    :description: Various other useful commands
@@ -327,7 +336,6 @@ variables and functions with their descriptions.
  #+findex: consult-theme
  #+findex: consult-man
  #+findex: consult-xref
- #+findex: consult-org-clock-in
  - =consult-apropos=: Replacement for =apropos= with completion.
  - =consult-man=: Find Unix man page, via Unix =apropos= or =man -k=.
    The selected man page is opened using the Emacs =man= command.
@@ -347,8 +355,6 @@ variables and functions with their descriptions.
    candidates.
  - =consult-xref=: Integration with xref. This function can be set as
    as =xref-show-xrefs-function= and =xref-show-definitions-function=.
- - =consult-org-clock-in=: Select a task and clock into it. Supports
-   narrowing by heading level, priority and TODO state.
 
 * Special features
   :properties:

--- a/consult-org.el
+++ b/consult-org.el
@@ -100,16 +100,17 @@ buffer are offered."
    (consult--read
     (consult--with-increased-gc (consult-org--entries match scope))
     :prompt "Go to heading: "
-    :category 'consult-org
+    :category 'consult-org-heading
     :sort nil
-    :title (lambda (cand)
-             (let ((marker (car (get-text-property 0 'consult-location cand))))
-               (buffer-name (marker-buffer marker))))
+    :title (unless (member scope '(nil 'tree 'region 'region-start-level 'file))
+             ;; Don't add titles when only showing entries from current buffer
+             (lambda (cand)
+               (let ((marker (car (get-text-property 0 'consult-location cand))))
+                 (buffer-name (marker-buffer marker)))))
     :narrow (consult-org--narrow)
     :require-match t
     :lookup #'consult--lookup-location
     :history '(:input consult-org--history)
-    :add-history (when (featurep 'org-clock) org-clock-current-task)
     :state (consult--jump-preview))))
 
 ;;;###autoload
@@ -150,7 +151,7 @@ recent clocked item."
            (and (member m1 org-clock-history)
                 (not (member m1 (member m2 org-clock-history))))))))
      :prompt "Clock in: "
-     :category 'consult-org
+     :category 'consult-org-heading
      :sort nil
      :title (lambda (cand)
               (let ((m (car (get-text-property 0 'consult-location cand))))

--- a/consult-org.el
+++ b/consult-org.el
@@ -1,0 +1,164 @@
+;;; consult-org.el --- Consult commands for org-mode -*- lexical-binding: t -*-
+
+;; Author: Daniel Mendler and Consult contributors
+;; Maintainer: Daniel Mendler <mail@daniel-mendler.de>
+;; Created: 2020
+;; License: GPL-3.0-or-later
+;; Version: 0.6
+;; Package-Requires: ((consult "0.6") (org "9.1") (emacs "26.1"))
+;; Homepage: https://github.com/minad/consult
+
+;; This file is not part of GNU Emacs.
+
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Provides a completing-read interface for some Org mode
+;; actions. This is an extra package, to allow lazy loading of Org.
+
+;;; Code:
+
+(require 'consult)
+(require 'org-agenda)
+(require 'org-clock)
+
+(defvar consult-org--history nil)
+
+(defvar consult-org--narrow
+  (append
+   ;; TODO keywords
+   (seq-filter
+    (lambda (it) (<= ?a (car it) ?z))
+    (mapcar (lambda (k)
+                  (list (downcase (string-to-char k)) k
+                        (lambda (cand)
+                          (string-equal k (get-text-property 0 'consult-org-todo cand)))))
+            (mapcan 'cdr org-todo-keywords)))
+   ;; Priorities
+   (mapcar (lambda (c)
+             (list c
+                   (format "Priority %c" c)
+                   (lambda (cand)
+                     (eq c (get-text-property 0 'consult-org-priority cand)))))
+           (number-sequence (max ?A org-highest-priority)
+                            (min ?Z org-lowest-priority)))
+   ;; Outline levels
+   (mapcar (lambda (i)
+             (list (+ i ?0)
+                   (format "Level %i" i)
+                   (lambda (cand)
+                     (>= i (get-text-property 0 'consult-org-level cand)))))
+           (number-sequence 1 9))))
+
+(defun consult-org--narrow ()
+  (cons (lambda (cand)
+          (funcall (nth 2 (assoc consult--narrow consult-org--narrow))
+                   cand))
+        (mapcar (pcase-lambda (`(,c ,s _)) (cons c s))
+                consult-org--narrow)))
+
+(defun consult-org--entries (match scope &rest skip)
+  "Return a list of consult locations from Org entries.
+
+MATCH, SCOPE and SKIP are as in `org-map-entries'."
+  (setq org-outline-path-cache nil)
+  (apply
+   #'org-map-entries
+   (lambda ()
+     (pcase-let ((`(_ ,level ,todo ,prio) (org-heading-components)))
+       (consult--location-candidate
+        (org-format-outline-path (org-get-outline-path t t))
+        (point-marker)
+        (current-line)
+        'consult-org-level level
+        'consult-org-todo todo
+        'consult-org-priority prio)))
+   match scope skip))
+
+;;;###autoload
+(defun consult-org-goto (&optional match scope)
+  "Jump to an Org heading.
+
+MATCH and SCOPE are as in `org-map-entries' and determine which
+entries are offered.  By default, all entries of the current
+buffer are offered."
+  (interactive (unless (derived-mode-p 'org-mode)
+                 (user-error "Must be called from an Org buffer.")))
+  (consult--jump
+   (consult--read
+    (consult--with-increased-gc (consult-org--entries match scope))
+    :prompt "Go to heading: "
+    :category 'consult-org
+    :sort nil
+    :title (lambda (cand)
+             (let ((marker (car (get-text-property 0 'consult-location cand))))
+               (buffer-name (marker-buffer marker))))
+    :narrow (consult-org--narrow)
+    :require-match t
+    :lookup #'consult--lookup-location
+    :history '(:input consult-org--history)
+    :add-history (when (featurep 'org-clock) org-clock-current-task)
+    :state (consult--jump-preview))))
+
+;;;###autoload
+(defun consult-org-agenda (&optional match)
+  "Jump to an Org agenda heading.
+
+By default, all agenda entries are offered.  MATCH is as in
+`org-map-entries' and can used to refine this."
+  (interactive)
+  (consult-org-goto match 'agenda))
+
+;;;###autoload
+(defun consult-org-clock-in (&optional match scope)
+  "Clock into an Org heading.
+
+MATCH and SCOPE are as in `org-map-entries' and determine which
+entries are offered.  By default, offer entries of files with a
+recent clocked item."
+  (interactive)
+  (unless scope
+    (org-clock-load)
+    (setq scope (thread-last org-clock-history
+                  (mapcar 'marker-buffer)
+                  (mapcar 'buffer-file-name)
+                  seq-uniq
+                  (seq-remove 'null))))
+  (org-clock-clock-in
+   (list
+    (consult--read
+     (consult--with-increased-gc
+      (sort ;; Recent items first, everything else in their original order
+       (consult-org--entries match scope)
+       (lambda (c1 c2)
+         (let ((m1 (car (get-text-property 0 'consult-location c1)))
+               (m2 (car (get-text-property 0 'consult-location c2))))
+           (and (member m1 org-clock-history)
+                (not (member m1 (member m2 org-clock-history))))))))
+     :prompt "Clock in: "
+     :category 'consult-org
+     :sort nil
+     :title (lambda (cand)
+              (let ((m (car (get-text-property 0 'consult-location cand))))
+                (if (member m org-clock-history)
+                    "Recent"
+                  (buffer-name (marker-buffer m)))))
+     :narrow (consult-org--narrow)
+     :require-match t
+     :lookup #'consult--lookup-location
+     :history '(:input consult-org--history)))))
+
+(provide 'consult-org)
+;;; consult-org.el ends here

--- a/consult-org.el
+++ b/consult-org.el
@@ -65,17 +65,19 @@ MATCH, SCOPE and SKIP are as in `org-map-entries'."
     (apply
      #'org-map-entries
      (lambda ()
+       ;; TODO: Is there no better way to obtain the line number? I guess it is guaranteed that
+       ;; `org-map-entries' iterates over all entries in a file in order.
        (unless (eq buffer (current-buffer))
          (setq opoint (point-min)
                line 1
                buffer (current-buffer)
-               org-outline-path-cache nil))
+               org-outline-path-cache nil)) ;; Reset the cache since `org-get-outline-path' uses the cache
        (setq line (+ line (consult--count-lines (prog1 (point)
                                                   (goto-char opoint))))
              opoint (point))
        (pcase-let ((`(_ ,level ,todo ,prio) (org-heading-components)))
          (consult--location-candidate
-          (org-format-outline-path (org-get-outline-path t t))
+          (org-format-outline-path (org-get-outline-path 'with-self 'use-cache))
           (point-marker)
           line
           'consult-org--level level
@@ -158,6 +160,7 @@ recent clocked item."
     (org-clock-clock-in
      (list
       (consult--read
+       ;; TODO This code should also go to `consult-org--clock-in-candidates'
        (nconc
         (seq-filter #'stringp
                     (mapcar (lambda (m) (gethash m recent))

--- a/consult-org.el
+++ b/consult-org.el
@@ -119,6 +119,8 @@ buffer are offered."
 By default, all agenda entries are offered.  MATCH is as in
 `org-map-entries' and can used to refine this."
   (interactive)
+  (unless org-agenda-files
+    (user-error "No agenda files"))
   (consult-org-heading match 'agenda))
 
 ;;;###autoload
@@ -129,13 +131,13 @@ MATCH and SCOPE are as in `org-map-entries' and determine which
 entries are offered.  By default, offer entries of files with a
 recent clocked item."
   (interactive)
-  (unless scope
-    (org-clock-load)
-    (setq scope (thread-last org-clock-history
-                  (mapcar 'marker-buffer)
-                  (mapcar 'buffer-file-name)
-                  seq-uniq
-                  (seq-remove 'null))))
+  (setq scope (or scope
+                  (thread-last (progn (org-clock-load) org-clock-history)
+                    (mapcar 'marker-buffer)
+                    (mapcar 'buffer-file-name)
+                    seq-uniq
+                    (seq-remove 'null))
+                  (user-error "No recent clocked tasks")))
   (org-clock-clock-in
    (list
     (consult--read

--- a/consult-org.el
+++ b/consult-org.el
@@ -100,7 +100,7 @@ buffer are offered."
    (consult--read
     (consult--with-increased-gc (consult-org--entries match scope))
     :prompt "Go to heading: "
-    :category 'consult-org-heading
+    :category 'consult-location
     :sort nil
     :title (unless (member scope '(nil 'tree 'region 'region-start-level 'file))
              ;; Don't add titles when only showing entries from current buffer
@@ -117,7 +117,7 @@ buffer are offered."
 (defun consult-org-agenda (&optional match)
   "Jump to an Org agenda heading.
 
-By default, all agenda entries are offered.  MATCH is as in
+By default, all agenda entries are offered. MATCH is as in
 `org-map-entries' and can used to refine this."
   (interactive)
   (unless org-agenda-files
@@ -125,11 +125,11 @@ By default, all agenda entries are offered.  MATCH is as in
   (consult-org-heading match 'agenda))
 
 ;;;###autoload
-(defun consult-org-clock (&optional match scope)
+(defun consult-org-clock-in (&optional match scope)
   "Clock into an Org heading.
 
 MATCH and SCOPE are as in `org-map-entries' and determine which
-entries are offered.  By default, offer entries of files with a
+entries are offered. By default, offer entries of files with a
 recent clocked item."
   (interactive)
   (setq scope (or scope
@@ -151,7 +151,7 @@ recent clocked item."
            (and (member m1 org-clock-history)
                 (not (member m1 (member m2 org-clock-history))))))))
      :prompt "Clock in: "
-     :category 'consult-org-heading
+     :category 'consult-location
      :sort nil
      :title (lambda (cand)
               (let ((m (car (get-text-property 0 'consult-location cand))))

--- a/consult-org.el
+++ b/consult-org.el
@@ -86,12 +86,13 @@ buffer are offered."
    :prompt "Go to heading: "
    :category 'consult-org-heading
    :sort nil
-   :group (unless (memq scope '(nil tree region region-start-level file))
-            ;; Don't add titles when only showing entries from current buffer
-            (apply-partially
-              #'consult--group-by-title
-              (lambda (cand)
-                (buffer-name (marker-buffer (car (get-text-property 0 'consult-org-heading cand)))))))
+   :title
+   (unless (memq scope '(nil tree region region-start-level file))
+     ;; Don't add titles when only showing entries from current buffer
+     (lambda (cand transform)
+       (if transform
+           cand
+         (buffer-name (marker-buffer (car (get-text-property 0 'consult-org-heading cand)))))))
    :narrow (consult-org--narrow)
    :require-match t
    :lookup

--- a/consult-org.el
+++ b/consult-org.el
@@ -102,7 +102,7 @@ buffer are offered."
     :prompt "Go to heading: "
     :category 'consult-location
     :sort nil
-    :title (unless (member scope '(nil 'tree 'region 'region-start-level 'file))
+    :title (unless (member scope '(nil tree region region-start-level file))
              ;; Don't add titles when only showing entries from current buffer
              (lambda (cand)
                (let ((marker (car (get-text-property 0 'consult-location cand))))

--- a/consult-org.el
+++ b/consult-org.el
@@ -145,6 +145,11 @@ recent clocked item."
                       (mapcar #'buffer-file-name)
                       (delete-dups)
                       (delq nil))
+                    ;; TODO use current file as scope as fallback?
+                    ;; I am still not entirely happy with the idea of using the list of files
+                    ;; containing recent clock entries as scope. Here we invent some new scope
+                    ;; which is not present in Org. It may be preferrable to use either the current Org
+                    ;; file or the agenda or maybe we could even define our own org scope variable?
                     (user-error "No recent clocked tasks")))
          (candidates (consult--with-increased-gc
                       (consult-org--entries match scope)))

--- a/consult-org.el
+++ b/consult-org.el
@@ -61,11 +61,10 @@ MATCH, SCOPE and SKIP are as in `org-map-entries'."
     (apply
      #'org-map-entries
      (lambda ()
+        ;; Reset the cache when the buffer changes, since `org-get-outline-path' uses the cache
        (unless (eq buffer (current-buffer))
-         ;; TODO is it necessary to reset the cache? Is `org-format-outline-path' incapable of
-         ;; detecting if the buffer changed?
          (setq buffer (current-buffer)
-               org-outline-path-cache nil)) ;; Reset the cache since `org-get-outline-path' uses the cache
+               org-outline-path-cache nil))
        (pcase-let ((`(_ ,level ,todo ,prio . _) (org-heading-components))
                    (cand (org-format-outline-path (org-get-outline-path 'with-self 'use-cache))))
          (put-text-property 0 1 'consult-org-heading (list (point-marker) level todo prio) cand)

--- a/consult-org.el
+++ b/consult-org.el
@@ -82,21 +82,21 @@ buffer are offered."
    :prompt "Go to heading: "
    :category 'consult-org-heading
    :sort nil
+   :require-match t
+   :history '(:input consult-org--history)
+   :narrow (consult-org--narrow)
+   :state (consult--jump-state)
    :title
+   ;; Don't add titles when only showing entries from current buffer
    (unless (memq scope '(nil tree region region-start-level file))
-     ;; Don't add titles when only showing entries from current buffer
      (lambda (cand transform)
        (if transform
            cand
          (buffer-name (marker-buffer (car (get-text-property 0 'consult-org-heading cand)))))))
-   :narrow (consult-org--narrow)
-   :require-match t
    :lookup
    (lambda (_ candidates cand)
      (when-let (found (member cand candidates))
-       (car (get-text-property 0 'consult-org-heading (car found)))))
-   :history '(:input consult-org--history)
-   :state (consult--jump-state)))
+       (car (get-text-property 0 'consult-org-heading (car found)))))))
 
 ;;;###autoload
 (defun consult-org-agenda (&optional match)

--- a/consult-org.el
+++ b/consult-org.el
@@ -1,13 +1,5 @@
 ;;; consult-org.el --- Consult commands for org-mode -*- lexical-binding: t -*-
 
-;; Author: Daniel Mendler and Consult contributors
-;; Maintainer: Daniel Mendler <mail@daniel-mendler.de>
-;; Created: 2020
-;; License: GPL-3.0-or-later
-;; Version: 0.6
-;; Package-Requires: ((consult "0.6") (org "9.1") (emacs "26.1"))
-;; Homepage: https://github.com/minad/consult
-
 ;; This file is not part of GNU Emacs.
 
 ;; This program is free software: you can redistribute it and/or modify

--- a/consult-org.el
+++ b/consult-org.el
@@ -53,7 +53,7 @@
                                            (min ?Z org-lowest-priority)))
                   todo-keywords))))
 
-(defun consult-org--headlines (match scope &rest skip)
+(defun consult-org--headings (match scope &rest skip)
   "Return a list of Org heading candidates.
 
 MATCH, SCOPE and SKIP are as in `org-map-entries'."
@@ -82,7 +82,7 @@ buffer are offered."
   (interactive (unless (derived-mode-p 'org-mode)
                  (user-error "Must be called from an Org buffer")))
   (consult--read
-   (consult--with-increased-gc (consult-org--headlines match scope))
+   (consult--with-increased-gc (consult-org--headings match scope))
    :prompt "Go to heading: "
    :category 'consult-org-heading
    :sort nil

--- a/consult.texi
+++ b/consult.texi
@@ -49,6 +49,7 @@ Available commands
 * Compilation errors::           Jumping to compilation errors
 * Histories::                    Navigating histories
 * Modes::                        Toggling minor modes and executing commands
+* Org Mode::                     Org-specific commands
 * Miscellaneous::                Various other useful commands
 
 Special features
@@ -133,6 +134,7 @@ variables and functions with their descriptions.
 * Compilation errors::           Jumping to compilation errors
 * Histories::                    Navigating histories
 * Modes::                        Toggling minor modes and executing commands
+* Org Mode::                     Org-specific commands
 * Miscellaneous::                Various other useful commands
 @end menu
 
@@ -252,8 +254,6 @@ If a region is active, store the region in register @samp{x}.
 @findex consult-outline
 @findex consult-imenu
 @findex consult-project-imenu
-@findex consult-org-heading
-@findex consult-org-agenda
 @itemize
 @item
 @samp{consult-goto-line}: Jump to line number enhanced with live preview.
@@ -275,14 +275,6 @@ live preview, recursive editing and narrowing.
 the same major mode as the current buffer. Supports live preview,
 recursive editing and narrowing. This feature has been inspired by
 @uref{https://github.com/vspinu/imenu-anywhere, imenu-anywhere}.
-@item
-@samp{consult-org-heading}: Similar to @samp{consult-outline}, for Org
-buffers. Supports narrowing by heading level, priority and TODO
-state, as well as live preview and recursive editing.
-@item
-@samp{consult-org-agenda}: Jump to an agenda heading. Supports
-narrowing by heading level, priority and TODO state, as well as
-live preview and recursive editing.
 @end itemize
 
 @node Search
@@ -429,6 +421,26 @@ or major modes. Supports narrowing to local-minor/global-minor/major
 mode via the keys @samp{l/g/m}.
 @end itemize
 
+@node Org Mode
+@section Org Mode
+
+@findex consult-org-clock-in
+@findex consult-org-heading
+@findex consult-org-agenda
+@itemize
+@item
+@samp{consult-org-heading}: Similar to @samp{consult-outline}, for Org
+buffers. Supports narrowing by heading level, priority and TODO
+state, as well as live preview and recursive editing.
+@item
+@samp{consult-org-agenda}: Jump to an agenda heading. Supports
+narrowing by heading level, priority and TODO state, as well as
+live preview and recursive editing.
+@item
+@samp{consult-org-clock-in}: Select a task and clock into it. Supports
+narrowing by heading level, priority and TODO state.
+@end itemize
+
 @node Miscellaneous
 @section Miscellaneous
 
@@ -438,7 +450,6 @@ mode via the keys @samp{l/g/m}.
 @findex consult-theme
 @findex consult-man
 @findex consult-xref
-@findex consult-org-clock-in
 @itemize
 @item
 @samp{consult-apropos}: Replacement for @samp{apropos} with completion.
@@ -465,9 +476,6 @@ candidates.
 @item
 @samp{consult-xref}: Integration with xref. This function can be set as
 as @samp{xref-show-xrefs-function} and @samp{xref-show-definitions-function}.
-@item
-@samp{consult-org-clock-in}: Select a task and clock into it. Supports
-narrowing by heading level, priority and TODO state.
 @end itemize
 
 @node Special features

--- a/consult.texi
+++ b/consult.texi
@@ -424,7 +424,6 @@ mode via the keys @samp{l/g/m}.
 @node Org Mode
 @section Org Mode
 
-@findex consult-org-clock-in
 @findex consult-org-heading
 @findex consult-org-agenda
 @itemize
@@ -436,9 +435,6 @@ state, as well as live preview and recursive editing.
 @samp{consult-org-agenda}: Jump to an agenda heading. Supports
 narrowing by heading level, priority and TODO state, as well as
 live preview and recursive editing.
-@item
-@samp{consult-org-clock-in}: Select a task and clock into it. Supports
-narrowing by heading level, priority and TODO state.
 @end itemize
 
 @node Miscellaneous

--- a/consult.texi
+++ b/consult.texi
@@ -252,6 +252,8 @@ If a region is active, store the region in register @samp{x}.
 @findex consult-outline
 @findex consult-imenu
 @findex consult-project-imenu
+@findex consult-org-heading
+@findex consult-org-agenda
 @itemize
 @item
 @samp{consult-goto-line}: Jump to line number enhanced with live preview.
@@ -273,6 +275,14 @@ live preview, recursive editing and narrowing.
 the same major mode as the current buffer. Supports live preview,
 recursive editing and narrowing. This feature has been inspired by
 @uref{https://github.com/vspinu/imenu-anywhere, imenu-anywhere}.
+@item
+@samp{consult-org-heading}: Similar to @samp{consult-outline}, for Org
+buffers. Supports narrowing by heading level, priority and TODO
+state, as well as live preview and recursive editing.
+@item
+@samp{consult-org-agenda}: Jump to an agenda heading. Supports
+narrowing by heading level, priority and TODO state, as well as
+live preview and recursive editing.
 @end itemize
 
 @node Search
@@ -428,6 +438,7 @@ mode via the keys @samp{l/g/m}.
 @findex consult-theme
 @findex consult-man
 @findex consult-xref
+@findex consult-org-clock-in
 @itemize
 @item
 @samp{consult-apropos}: Replacement for @samp{apropos} with completion.
@@ -454,6 +465,9 @@ candidates.
 @item
 @samp{consult-xref}: Integration with xref. This function can be set as
 as @samp{xref-show-xrefs-function} and @samp{xref-show-definitions-function}.
+@item
+@samp{consult-org-clock-in}: Select a task and clock into it. Supports
+narrowing by heading level, priority and TODO state.
 @end itemize
 
 @node Special features


### PR DESCRIPTION
Possible org-related commands were already discussed in the wishlist thread. In my opinion, the two most useful actions would be jumping to an agenda item and clocking in. This pull request is a draft for those two commands.

Possible improvements:
* Flatten the tree structure. That is, insetead of showing candidates
   ```
   * Heading 1
   ** Subheading 1.1
   * Heading 2
   ```
   display this as
   ```
   Heading 1
   Heading 1 > Subheading 1.1
   Heading 2
  ```
* Add narrowing. One could go wild here, and I don't even know what all the possibilities are. Some ideas:
   * By TODO/DONE state
   * By priority
   * By outline level ≤ n
* Performance: Building the candidate list could be slow, if one has lots of stuff in their agenda files. In my case it only takes a fraction of a second, but a lag is still noticeable.
* Category: should we use `consult-location` here, or invent a new category to allow attaching extra information to candidates, for instance the information needed for narrowing? Also, do I get it correctly that using lists of strings instead of lists of conses is the preferred way to build a candidate list now?
* Fontification: I think I'd rather remove the org heading faces from the candidates. I like to use larger, variable pitch faces for `outline-n`.
* In `consult-clock-in`, it would be nice to somehow inform the user about the currently clocked task, if any. One possibility would be to show the task name in the prompt, as in `Clock in (current: Heading 1): `. Any other suggestions?

What do you think?