### PR TITLE
Add narrowing to consult-outline

### DIFF
--- a/consult.el
+++ b/consult.el
@@ -843,11 +843,12 @@ Also create a which-key pseudo key to show the description."
   (lambda (cand)
     (list cand (format fmt (cdr (get-text-property 0 'consult-location cand))) ""))))
 
-(defun consult--location-candidate (cand marker line)
+(defun consult--location-candidate (cand marker line &rest props)
   "Add MARKER and LINE as 'consult-location text property to CAND.
-Furthermore append tofu-encoded MARKER suffix for disambiguation."
+Furthermore add the additional text properties PROPS, and append
+tofu-encoded MARKER suffix for disambiguation."
   (setq cand (concat cand (consult--tofu-encode marker)))
-  (put-text-property 0 1 'consult-location (cons marker line) cand)
+  (add-text-properties 0 1 `(consult-location (,marker . ,line) ,@props) cand)
   cand)
 
 (defsubst consult--buffer-substring (beg end &optional fontify)
@@ -1952,9 +1953,9 @@ See `multi-occur' for the meaning of the arguments BUFS, REGEXP and NLINES."
                (consult--buffer-substring (line-beginning-position)
                                           (line-end-position)
                                           'fontify)
-               (point-marker) line)
+               (point-marker) line
+               'consult-level (funcall level-function))
               candidates)
-        (put-text-property 0 1 'consult-level (funcall level-function) (car candidates))
         (unless (eobp) (forward-char 1))))
     (unless candidates
       (user-error "No headings"))


### PR DESCRIPTION
Here's a sketch for the narrowing by outline level in `consult-outline`.

Some comments:
* I don't like the `consult--ouline-level` function too much. It would be easy enough to compute the level when building the candidate list, but then I would have to change `consult--location-candidate` to allow including this extra datum in each candidate.
* For now, I'm requiring `outline` in the body of `consult--ouline-level`. If we reimplemented code from `outline` to avoid requiring it, it wouldn't add that many lines of code. Still, I don't quite see why not `(require 'outline)` in the body of `consult-outline` itself. Then `consult--outline-candidates` could also be slightly simplified.
* There's nothing forcing outline levels to be contiguous numbers (for instance, the smallest level in consult.el is 4). I think it's best not to be overly fancy when handling this. So I'm just shifting outline numbers so that `Level ≤ 1` narrows to the smallest level, but otherwise leave any holes as they are. This also means it's impossible to reach the level of `(defun` in consult.el, because those have `outline-level=16` a.k.a. `Level ≤ 13`.