### PR TITLE
Show in-buffer previews for consult-history

### DIFF
--- a/README.org
+++ b/README.org
@@ -864,9 +864,10 @@ contributed.
  ;; Note that you should bind <S-up> and <S-down> in the
  ;; `minibuffer-local-completion-map' or `selectrum-minibuffer-map'
  ;; to the commands which select the previous or next candidate.
- (setq consult-config `((consult-theme :preview-key nil)
-                        (consult-buffer :preview-key ,(kbd "M-p"))
-                        (consult-line :preview-key (,(kbd "<S-down>") ,(kbd "<S-up>")))))
+ (with-eval-after-load 'consult
+   (add-to-list 'consult-config '(consult-theme :preview-key nil))
+   (add-to-list 'consult-config '(consult-buffer :preview-key ,(kbd "M-p")))
+   (add-to-list 'consult-config '(consult-line :preview-key (,(kbd "<S-down>") ,(kbd "<S-up>")))))
  #+end_src
 
  Generally it is possible to modify commands for your individual needs by the

--- a/consult.el
+++ b/consult.el
@@ -338,7 +338,7 @@ should not be considered as stable as the public API."
   :group 'faces)
 
 (defface consult-preview-line
-  '((t :inherit consult-preview-region :extend t))
+  '((t :inherit consult-preview-insertion :extend t))
   "Face used to for line previews.")
 
 (defface consult-preview-match
@@ -353,17 +353,13 @@ should not be considered as stable as the public API."
   '((t :inherit isearch-fail))
   "Face used to for cursor previews and marks in `consult-compile-error'.")
 
-(defface consult-preview-yank
-  '((t :inherit consult-preview-region))
-  "Face used to for yank previews in `consult-yank'.")
-
-(defface consult-preview-history
-  '((t :inherit consult-preview-region))
-  "Face used to for in-buffer history previews in `consult-history'.")
-
-(defface consult-preview-region
+(defface consult-preview-insertion
   '((t :inherit region))
-  "Face used to for completion previews in `consult-completion-in-region'.")
+  "Face used to for previews of text to be inserted.
+Used by `consult-completion-in-region', `consult-yank' and `consult-history'.")
+
+(define-obsolete-face-alias 'consult-preview-region
+  'consult-preview-insertion "0.6")
 
 (defface consult-narrow-indicator
   '((t :inherit warning))
@@ -2528,7 +2524,7 @@ These configuration options are supported:
                    (consult--with-preview
                        preview-key
                        ;; preview state
-                       (consult--region-preview start end 'consult-preview-region)
+                       (consult--region-preview start end 'consult-preview-insertion)
                        ;; transformation function
                        (if (eq category 'file)
                            (if (file-name-absolute-p initial)
@@ -2681,7 +2677,7 @@ If no MODES are specified, use currently active major and minor modes."
      (point)
      ;; If previous command is yank, hide previously yanked text
      (or (and (eq last-command 'yank) (mark t)) (point))
-     'consult-preview-yank))))
+     'consult-preview-insertion))))
 
 ;; Insert selected text.
 ;; Adapted from the Emacs yank function.
@@ -3117,7 +3113,7 @@ In order to select from a specific HISTORY, pass the history variable as argumen
                      'command)
                 :state
                 (consult--region-preview (point) (point)
-                                         'consult-preview-history)
+                                         'consult-preview-insertion)
                 :sort nil))))
     (when (minibufferp)
       (delete-minibuffer-contents))

--- a/consult.el
+++ b/consult.el
@@ -2467,16 +2467,17 @@ The candidates are previewed in the region from START to END
 using the given FACE. This function is used as the `:state'
 argument for `consult--read' in the `consult-yank' family of
 functions and in `consult-completion-in-region'."
-  (let (ov)
-    (lambda (cand restore)
-      (if restore
-          (when ov (delete-overlay ov))
-        (unless ov (setq ov (consult--overlay start end 'invisible t)))
-        ;; Use `add-face-text-property' on a copy of "cand in order to merge face properties
-        (setq cand (copy-sequence cand))
-        (add-face-text-property 0 (length cand) face t cand)
-        ;; Use the `before-string' property since the overlay might be empty.
-        (overlay-put ov 'before-string cand)))))
+  (unless (minibufferp)
+    (let (ov)
+      (lambda (cand restore)
+        (if restore
+            (when ov (delete-overlay ov))
+          (unless ov (setq ov (consult--overlay start end 'invisible t)))
+          ;; Use `add-face-text-property' on a copy of "cand in order to merge face properties
+          (setq cand (copy-sequence cand))
+          (add-face-text-property 0 (length cand) face t cand)
+          ;; Use the `before-string' property since the overlay might be empty.
+          (overlay-put ov 'before-string cand))))))
 
 ;; Use minibuffer completion as the UI for completion-at-point
 ;;;###autoload
@@ -3115,9 +3116,8 @@ In order to select from a specific HISTORY, pass the history variable as argumen
                      (eq minibuffer-history-variable 'extended-command-history)
                      'command)
                 :state
-                (unless (minibufferp)
-                  (consult--region-preview (point) (point)
-                                           'consult-preview-history))
+                (consult--region-preview (point) (point)
+                                         'consult-preview-history)
                 :sort nil))))
     (when (minibufferp)
       (delete-minibuffer-contents))

--- a/consult.el
+++ b/consult.el
@@ -324,13 +324,13 @@ Each element of the list must have the form '(char name handler)."
 (defcustom consult-config (list #'consult--config-term-no-preview)
   "Command configuration list, which allows fine-grained configuration.
 
-Each element of the list is either a function, taking a command
-as its sole argument and returning a plist or a cons cell of the
-form (COMMAND-NAME . PLIST). The plist of the first matching
-element will be passed to `consult--read' as options, when called
-from the corresponding command. Note that the options depend on
-the private `consult--read' API and should not be considered as
-stable as the public API.
+Each element of the list is either a cons cell of the
+form (COMMAND-NAME . PLIST) or a function, taking a command as
+its sole argument and returning a plist. The plists of all
+matching elements are combined and passed to `consult--read' as
+options. Note that the options depend on the private
+`consult--read' API and should not be considered as stable as the
+public API.
 
 A function is considered matching if it returns a non-nil plist
 and a cons cell is considered matching if its car matches the
@@ -893,16 +893,12 @@ MARKER is the cursor position."
 COMMAND is the command to search the alist for."
   (let ((tail consult-config)
         (ret nil))
-    (while
-        (and tail
-             (let ((elem (car tail)))
-               (cond ((functionp elem)
-                      (setq ret (funcall elem command))
-                      (null ret))
-                     ((eq (car elem) command)
-                      (setq ret (cdr elem))
-                      nil)
-                     (t t))))
+    (while tail
+      (let ((elem (car tail)))
+        (cond ((functionp elem)
+               (setq ret (append ret (funcall elem command))))
+              ((eq (car elem) command)
+               (setq ret (append ret (cdr elem))))))
       (setq tail (cdr tail)))
     ret))
 

--- a/consult.el
+++ b/consult.el
@@ -357,6 +357,10 @@ should not be considered as stable as the public API."
   '((t :inherit consult-preview-region))
   "Face used to for yank previews in `consult-yank'.")
 
+(defface consult-preview-history
+  '((t :inherit consult-preview-region))
+  "Face used to for in-buffer history previews in `consult-history'.")
+
 (defface consult-preview-region
   '((t :inherit region))
   "Face used to for completion previews in `consult-completion-in-region'.")
@@ -3110,6 +3114,10 @@ In order to select from a specific HISTORY, pass the history variable as argumen
                 (and (minibufferp)
                      (eq minibuffer-history-variable 'extended-command-history)
                      'command)
+                :state
+                (unless (minibufferp)
+                  (consult--region-preview (point) (point)
+                                           'consult-preview-history))
                 :sort nil))))
     (when (minibufferp)
       (delete-minibuffer-contents))

--- a/consult.el
+++ b/consult.el
@@ -321,7 +321,7 @@ Each element of the list must have the form '(char name predicate)."
 Each element of the list must have the form '(char name handler)."
   :type '(repeat (list character string function)))
 
-(defcustom consult-config nil
+(defcustom consult-config (list #'consult--config-term-no-preview)
   "Command configuration list, which allows fine-grained configuration.
 
 Each element of the list is either a function, taking a command
@@ -1040,6 +1040,16 @@ FACE is the cursor face."
       (funcall preview cand restore)
       (when (and cand restore)
         (consult--jump cand)))))
+
+(defun consult--config-term-no-preview (command)
+  "Return a plist to disable preview in `term-mode'.
+Insertion previews for `consult-yank', `consult-completion-in-region' and
+`consult-history' don't work well in `term-mode'. Putting this function into
+`consult-config' will disable them in `term-mode'"
+  (and (memq command '(consult-yank consult-yank-pop consult-history
+                                    consult-completion-in-region))
+       (derived-mode-p 'term-mode)
+       '(:preview-key nil)))
 
 (defun consult--with-preview-1 (preview-key state transform candidate fun)
   "Add preview support for FUN.


### PR DESCRIPTION
Quick addition of previews to consult-history.

Important note: Previews don't work well in term-mode (for comint and eshell
they work OK). But then again, consult-yank previews don't work well in
term-mode either as this is a general `consult--region-preview` issue with
term-mode.

The problem is that in term mode, when running readline-based programs such as
bash, the last prompt will frequently be redrawn, moving point, markers and
overlays to the beginning or the end of this prompt. The terminal's process
filter might also manually move point over trailing newlines to the end of the
prompt, I'm not sure.

The best solution would probably be to make region previews more robust against
buffer modifications and somehow make them work in term-mode, but I admit that
my experience with Emacs's terminal emulation is lacking.
