### PR TITLE
consult-narrow: Remove which-key pseudo keys

### DIFF
--- a/consult.el
+++ b/consult.el
@@ -804,19 +804,6 @@ Otherwise the `default-directory' is returned."
   (when (and consult-fontify-preserve jit-lock-mode)
     (jit-lock-fontify-now start end)))
 
-(defun consult--define-key (map key cmd desc)
-  "Bind CMD to KEY with DESC in MAP.
-Also create a which-key pseudo key to show the description."
-  (define-key map key (cons desc cmd))
-  ;; The which-key description is potentially fragile if something is changed on the side
-  ;; of which-key. Keep an eye on that. An alternative more standard-compliant method
-  ;; would be to use `menu-item', but this is unfortunately not yet supported by which-key
-  ;; and `describe-buffer-bindings'.
-  ;; See https://github.com/justbur/emacs-which-key/issues/177
-  (let ((idx (1- (length key))))
-    (define-key map (vconcat (seq-take key idx) (vector 'which-key (elt key idx)))
-      `(which-key (,(copy-sequence desc))))))
-
 (defmacro consult--with-increased-gc (&rest body)
   "Temporarily increase the gc limit in BODY to optimize for throughput."
   (let ((overwrite (make-symbol "overwrite")))
@@ -1224,11 +1211,11 @@ to make it available for commands with narrowing."
           consult--narrow-keys settings)))
   (when consult-narrow-key
     (dolist (pair consult--narrow-keys)
-      (consult--define-key map
-                           (vconcat consult-narrow-key (vector (car pair)))
-                           #'consult-narrow (cdr pair))))
+      (define-key map
+        (vconcat consult-narrow-key (vector (car pair)))
+        (cons (cdr pair) #'consult-narrow))))
   (when-let (widen (consult--widen-key))
-    (consult--define-key map widen #'consult-narrow "All")))
+    (define-key map widen (cons "All" #'consult-narrow))))
 
 ;;;; Splitting completion style
 


### PR DESCRIPTION
Use menu items instead, which are now supported by which-key.

See https://github.com/justbur/emacs-which-key/pull/308