### PR TITLE
consult-completing-read-multiple

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -2,6 +2,11 @@
 #+author: Daniel Mendler
 #+language: en
 
+* Development
+
+- =consult-mark=, =consult-global-mark=: Added optional marker list argument
+- =consult-completing-read-multiple=: New function
+
 * Version 0.9 (2021-06-22)
 
 - Add =consult-preview-excluded-hooks=

--- a/README.org
+++ b/README.org
@@ -343,6 +343,7 @@ their descriptions.
  #+findex: consult-apropos
  #+findex: consult-file-externally
  #+findex: consult-completion-in-region
+ #+findex: consult-completing-read-multiple
  #+findex: consult-theme
  #+findex: consult-man
  #+findex: consult-preview-at-point
@@ -384,6 +385,9 @@ their descriptions.
    buffer to the minibuffer, the server does not receive the updated input. Lsp
    completion should work with Corfu or Company though, which perform the
    completion directly in the original buffer.
+  - =consult-completing-read-multiple=: Enhanced drop-in replacement for
+    =completing-read-multiple= which works better for long candidates.
+
 * Special features
   :properties:
   :description: Enhancements over built-in `completing-read'
@@ -834,6 +838,9 @@ contributed.
      ;; Use Consult to select xref locations with preview
      (setq xref-show-xrefs-function #'consult-xref
            xref-show-definitions-function #'consult-xref)
+
+     ;; Optionally replace `completing-read-multiple' with an enhanced version.
+     (advice-add #'completing-read-multiple :override #'consult-completing-read-multiple)
 
      ;; Configure other variables and modes in the :config section,
      ;; after lazily loading the package.

--- a/consult-icomplete.el
+++ b/consult-icomplete.el
@@ -27,14 +27,14 @@
 (require 'consult)
 (require 'icomplete)
 
-(defun consult-icomplete--refresh ()
-  "Refresh icomplete view, keep current candidate selected if possible."
+(defun consult-icomplete--refresh (&optional reset)
+  "Refresh icomplete view, keep current candidate unless RESET is non-nil."
   (when icomplete-mode
     (let ((top (car completion-all-sorted-completions)))
       (completion--flush-all-sorted-completions)
       ;; force flushing, otherwise narrowing is broken!
       (setq completion-all-sorted-completions nil)
-      (when top
+      (when (and top (not reset))
         (let* ((completions (completion-all-sorted-completions))
                (last (last completions))
                (before)) ;; completions before top

--- a/consult-selectrum.el
+++ b/consult-selectrum.el
@@ -60,11 +60,10 @@ See `consult--completion-filter' for arguments PATTERN, CANDS, CATEGORY and HIGH
 (defun consult-selectrum--refresh (&optional reset)
   "Refresh completion UI, keep current candidate unless RESET is non-nil."
   (when selectrum-is-active
-    (if consult--narrow
-        (setq-local selectrum-default-value-format nil)
-      (kill-local-variable 'selectrum-default-value-format))
+    (when consult--narrow
+      (setq-local selectrum-default-value-format nil))
     (when reset
-      (setq selectrum--history-hash nil))
+      (setq-local selectrum--history-hash nil))
     (selectrum-exhibit (not reset))))
 
 (defun consult-selectrum--split-wrap (orig split)
@@ -84,8 +83,14 @@ SPLIT is the splitter function."
     (setq-local selectrum-highlight-candidates-function
 		(consult-selectrum--split-wrap selectrum-highlight-candidates-function split))))
 
+(defun consult-selectrum--crm-setup ()
+  "Setup crm for Selectrum."
+  (when selectrum-is-active
+    (setq-local selectrum-default-value-format nil)))
+
 (add-hook 'consult--completion-candidate-hook #'consult-selectrum--candidate)
 (add-hook 'consult--completion-refresh-hook #'consult-selectrum--refresh)
+(add-hook 'consult--crm-setup-hook #'consult-selectrum--crm-setup)
 (advice-add #'consult--completion-filter :around #'consult-selectrum--filter-adv)
 (advice-add #'consult--split-setup :around #'consult-selectrum--split-setup-adv)
 

--- a/consult-selectrum.el
+++ b/consult-selectrum.el
@@ -31,6 +31,7 @@
 (defvar selectrum-highlight-candidates-function)
 (defvar selectrum-is-active)
 (defvar selectrum-refine-candidates-function)
+(defvar selectrum--history-hash)
 (declare-function selectrum-exhibit "ext:selectrum")
 (declare-function selectrum-get-current-candidate "ext:selectrum")
 
@@ -56,13 +57,15 @@ See `consult--completion-filter' for arguments PATTERN, CANDS, CATEGORY and HIGH
   "Return current selectrum candidate."
   (and selectrum-is-active (selectrum-get-current-candidate)))
 
-(defun consult-selectrum--refresh ()
-  "Refresh selectrum view."
+(defun consult-selectrum--refresh (&optional reset)
+  "Refresh completion UI, keep current candidate unless RESET is non-nil."
   (when selectrum-is-active
     (if consult--narrow
         (setq-local selectrum-default-value-format nil)
       (kill-local-variable 'selectrum-default-value-format))
-    (selectrum-exhibit 'keep-selected)))
+    (when reset
+      (setq selectrum--history-hash nil))
+    (selectrum-exhibit (not reset))))
 
 (defun consult-selectrum--split-wrap (orig split)
   "Wrap candidates highlight/refinement ORIG function, splitting the input using SPLIT."

--- a/consult-vertico.el
+++ b/consult-vertico.el
@@ -28,6 +28,8 @@
 
 ;; NOTE: It is not guaranteed that Vertico is available during compilation!
 (defvar vertico--input)
+(defvar vertico--history-hash)
+(defvar vertico--lock-candidate)
 (declare-function vertico--exhibit "ext:vertico")
 (declare-function vertico--candidate "ext:vertico")
 
@@ -35,10 +37,13 @@
   "Return current candidate for Consult preview."
   (and vertico--input (vertico--candidate 'highlight)))
 
-(defun consult-vertico--refresh ()
-  "Refresh completion UI, used by Consult async/narrowing."
+(defun consult-vertico--refresh (&optional reset)
+  "Refresh completion UI, keep current candidate unless RESET is non-nil."
   (when vertico--input
     (setq vertico--input t)
+    (when reset
+      (setq vertico--history-hash nil
+            vertico--lock-candidate nil))
     (vertico--exhibit)))
 
 (add-hook 'consult--completion-candidate-hook #'consult-vertico--candidate)

--- a/consult.el
+++ b/consult.el
@@ -441,6 +441,9 @@ should not be considered as stable as the public API.")
 (defvar consult--cache nil
   "Cached data populated by `consult--define-cache'.")
 
+(defvar consult--crm-setup-hook nil
+  "Hook executed in `consult-completing-read-multiple' minibuffer.")
+
 (defvar consult--completion-candidate-hook
   (list #'consult--default-completion-mb-candidate
         #'consult--default-completion-list-candidate)
@@ -2227,8 +2230,8 @@ See `completing-read-multiple' for the documentation of the arguments."
                            (when selected
                              (format " (%s selected): " (length selected)))))))
          (command)
-         (hook (make-symbol "consult--crm-hook"))
-         (wrapper (make-symbol "consult--crm-wrapper")))
+         (hook (make-symbol "consult--crm-post-command-hook"))
+         (wrapper (make-symbol "consult--crm-command-wrapper")))
     (fset wrapper
           (lambda ()
             (interactive)
@@ -2254,7 +2257,8 @@ See `completing-read-multiple' for the documentation of the arguments."
            (when-let (pos (string-match-p "\\(?: (default[^)]+)\\)?: \\'" prompt))
              (setq overlay (make-overlay (+ (point-min) pos) (+ (point-min) (length prompt))))
              (funcall update-overlay))
-           (add-hook 'pre-command-hook hook nil 'local)))
+           (add-hook 'pre-command-hook hook nil 'local)
+           (run-hooks 'consult--crm-setup-hook)))
       (funcall select-item
                (completing-read
                 prompt


### PR DESCRIPTION
@bdarcus @oantolin 

This is the generalized version of `simple-crm`. While this crm implementation is not the perfect solution and may still have other subtle issues, I am actually quite happy with it. I think it is a usability improvement in particular in combination with UIs like Vertico  or Selectrum, but it also works well with default completion. The function is a pretty cheap and non-intrusive addition, independent of the completion UI. This is much more maintainable, in contrast to baking some special crm support directly in the completion UI like Vertico.

My problem here is that I could not get this to work with Embark until now. My main concern is not the multi selection target finder, but the ability to allow `completing-read-multiple` commands to be used as Embark actions. Example: `M-x describe-face RET <select-face> M-.` or `M-x describe-face RET <select-face> C-. M-x describe-face RET`, where `M-./C-.`  are `embark-dwim/act` respectively. The issue is that the action gets stuck in the CRM loop.

Please give it a test. Maybe you have a good idea how to enable Embark support?