### PR TITLE
Fix `consult--command-split`

### DIFF
--- a/consult.el
+++ b/consult.el
@@ -536,7 +536,7 @@ ARGS is a list of commands or sources followed by the list of keyword-value pair
   (save-match-data
     (let ((opts (when (string-match " +--\\( +\\|\\'\\)" str)
                   (prog1 (substring str (match-end 0))
-                    (setq str (substring str 0 (match-end 0)))))))
+                    (setq str (substring str 0 (match-beginning 0)))))))
       (unless (string-blank-p str)
         ;; split-string-and-unquote fails if the quotes are invalid. Ignore it.
         (cons str (and opts (ignore-errors (split-string-and-unquote opts))))))))


### PR DESCRIPTION
Hello, @minad!

This is a small fix to make `consult--command-split` remove the `--` from the arguments when splitting an input.

#### Before: `--` is included in the arguments

```elisp
~ $ (consult--command-split "case -- --hidden --glob *backup")
("case -- " "--hidden" "--glob" "*backup")
```

`*consult-async*`: `--` is included as a string to match, `(?=.*--)`:

```txt
consult--async-process started ("rg" "--line-buffered" "--color=never" "--max-columns=1000" "--path-separator" "/" "--smart-case" "--no-heading" "--line-number" "." "-P" "-e" "^(?=.*case)(?=.*--)" "--hidden" "--glob" "*backup")
```

#### After: `--` is removed

```elisp
~ $ (consult--command-split "case -- --hidden --glob *backup")
("case" "--hidden" "--glob" "*backup")
```

`*consult-async*`:

```txt
consult--async-process started ("rg" "--line-buffered" "--color=never" "--max-columns=1000" "--path-separator" "/" "--smart-case" "--no-heading" "--line-number" "." "-P" "-e" "case" "--hidden" "--glob" "*backup")
```

On a different note, I quickly benchmarked ripgrep with [hyperfine](https://github.com/sharkdp/hyperfine). Running ripgrep with the PCRE2 engine seems to be generally slower than running it with the Rust engine. Do you think `consult-ripgrep` should default to using the PCRE2 engine, or shall we look into ways of using the Rust engine whenever possible?

An easy step would be to use ripgrep's `--auto-hybrid-regex` flag; this uses the PCRE2 engine only if needed. That would still use the PCRE2 engine a lot of the time (because Consult uses positive lookahead to match multiple strings), so we'd have to change that if we want to rely on the Rust engine.
