### PR TITLE
Call compilation-find-file from the correct directory

### DIFF
--- a/consult-compile.el
+++ b/consult-compile.el
@@ -67,20 +67,21 @@
 
 (defun consult-compile--error-lookup (_ candidates cand)
   "Lookup marker of CAND by accessing CANDIDATES list."
-  (when-let (cand (car (member cand candidates)))
-    (let ((marker (get-text-property 0 'consult-compile--marker cand))
-          (loc (get-text-property 0 'consult-compile--loc cand)))
-      (when (buffer-live-p (marker-buffer marker))
-        (consult--position-marker
-         ;; taken from compile.el
-         (apply #'compilation-find-file
-                marker
-                (caar (compilation--loc->file-struct loc))
-                (cadar (compilation--loc->file-struct loc))
-                (compilation--file-struct->formats
-                 (compilation--loc->file-struct loc)))
-         (compilation--loc->line loc)
-         (compilation--loc->col loc))))))
+  (when-let ((cand (car (member cand candidates)))
+             (marker (get-text-property 0 'consult-compile--marker cand))
+             (loc (get-text-property 0 'consult-compile--loc cand))
+             (buffer (marker-buffer marker))
+             (default-directory (buffer-local-value 'default-directory buffer)))
+    (consult--position-marker
+     ;; taken from compile.el
+     (apply #'compilation-find-file
+            marker
+            (caar (compilation--loc->file-struct loc))
+            (cadar (compilation--loc->file-struct loc))
+            (compilation--file-struct->formats
+             (compilation--loc->file-struct loc)))
+     (compilation--loc->line loc)
+     (compilation--loc->col loc))))
 
 (defun consult-compile--compilation-buffers (file)
   "Return a list of compilation buffers relevant to FILE."


### PR DESCRIPTION
This does the trick for me. We might also either enable recursive minibuffers, or just give up if `compilation-find-file` asks for a directory, but with an appropriate error message.

Fixes #301