### PR TITLE
Fix consult-xref preview on emacs master

### DIFF
--- a/consult-xref.el
+++ b/consult-xref.el
@@ -61,10 +61,17 @@
                      (xref-buffer-location
                       (xref-location-marker loc))
                      (xref-file-location
-                      (consult--position-marker
-                       (funcall open (oref loc file))
-                       (oref loc line)
-                       (oref loc column)))
+                      ;; As of Emacs 28, xref uses cl-defstruct,
+                      ;; whereas earlier versions use EIEIO
+                      (if (cl-struct-p loc)
+                          (consult--position-marker
+                           (funcall open (xref-file-location-file loc))
+                           (xref-file-location-line loc)
+                           (xref-file-location-column loc))
+                        (consult--position-marker
+                         (funcall open (oref loc file))
+                         (oref loc line)
+                         (oref loc column))))
                      (t (message "No preview for %s" (type-of loc)) nil))
                    nil)))))))
 


### PR DESCRIPTION
The internals of xref were changed to use cl-defstruct instead of
EIEIO, which breaks the use of `oref' in consult-xref--preview. With
this commit an additional code path is introduced which handles the
cl-defstruct case.

See [this commit](https://github.com/emacs-mirror/emacs/commit/86da812afb2572c7fead2bb07570b976bffd7c55).