### PR TITLE
 Make menu-item :fiter functions pure functions

### DIFF
--- a/consult.el
+++ b/consult.el
@@ -1306,8 +1306,9 @@ This command is used internally by the narrowing system of `consult--read'."
     "" nil :filter
     ,(lambda (&optional _)
        (when (string= (minibuffer-contents-no-properties) "")
-         (consult-narrow nil)
-         #'ignore))))
+         (lambda ()
+           (interactive)
+           (consult-narrow nil))))))
 
 (defconst consult--narrow-space
   `(menu-item
@@ -1318,9 +1319,10 @@ This command is used internally by the narrowing system of `consult--read'."
                                   (assoc (aref str 0) consult--narrow-keys))
                              (and (string= str "")
                                   (assoc 32 consult--narrow-keys))))
-           (delete-minibuffer-contents)
-           (consult-narrow (car pair))
-           #'ignore)))))
+           (lambda ()
+             (interactive)
+             (delete-minibuffer-contents)
+             (consult-narrow (car pair))))))))
 
 (defun consult-narrow-help ()
   "Print narrowing help as a `minibuffer-message'.


### PR DESCRIPTION
Currently the :filter functions for the menu-items used in narrowing
do the narrowing themselves; with this change they instead return a
command to do the narrowing. Returning a command is how the :filter
functions are meant to be used:

`:filter FILTER-FN'
     This property provides a way to compute the menu item dynamically.
     The property value FILTER-FN should be a function of one argument;
     when it is called, its argument will be REAL-BINDING.  The
     function should return the binding to use instead.

Moreover, it is not safe to have the side-effects carried out directly
in the filter function, per the manual:

     Emacs can call this function at any time that it does redisplay or
     operates on menu data structures, so you should write it so it can
     safely be called at any time.

This change will also fix oantolin/embark#388.