### PR TITLE
directory-prompt-1: format project.el path from provided absolute path

### DIFF
--- a/consult.el
+++ b/consult.el
@@ -802,13 +802,20 @@ The line beginning/ending BEG/END is bound in BODY."
         adir))))
 
 (defun consult--directory-prompt-1 (prompt dir)
-  "Format PROMPT, expand directory DIR and return them as a pair."
+  "Format PROMPT, expand directory DIR and return them as a pair.
+	
+  if the absolute path of DIR matches that of `(current-project)',
+format the prompt as a `project' "
   (let ((edir (file-name-as-directory (expand-file-name dir)))
-        (ddir (file-name-as-directory (expand-file-name default-directory))))
+        (ddir (file-name-as-directory (expand-file-name default-directory)))
+        (pdir (file-name-as-directory (expand-file-name (consult--project-root)))))
     (cons
-     (if (string= ddir edir)
-         (concat prompt ": ")
-       (format "%s (%s): " prompt (consult--abbreviate-directory dir)))
+     (cond
+      ((string= ddir edir) (concat prompt ": "))
+      ((string= edir pdir) 
+       (format "%s (%s %s): " prompt 
+	       "Project" (consult--project-name pdir)))
+      (t (format "%s (%s): " prompt (consult--abbreviate-directory dir))))
      edir)))
 
 (defun consult--directory-prompt (prompt dir)


### PR DESCRIPTION
Good day,

I'm adding some features to guix RDE  
https://sr.ht/~abcdw/rde/ and had some consistency trouble with  
respect to prompt formatting.  

If the following exposition checks out to you, please let me know  
what I can do to get a resolution merged.

Cheers for the great package, it's a real blast to use!
  Samuel

-- 

Currently, in consult-ripgrep, an abbreviated directory is used  
when a project (project.el) path is supplied.  

`consult--directory-prompt` has a provision to format the path  
when no DIR is provided to `consult-ripgrep`:  

function:consult--directory-prompt:
``` emacs-lisp
   ((when-let (root (consult--project-root))
      (cons (format "%s (Project %s): " prompt (consult--project-name root))
            root)))
```

but given the precedence of the conditions in `cond` the paths  
will be collapsed later if we have a non-nil DIR arg:

function:consult--directory-prompt:
``` emacs-lisp
   ((stringp dir) (consult--directory-prompt-1 prompt dir))
```

consequently, function:consult--directory-prompt-1:
```
(defun consult--directory-prompt-1 (prompt dir)
  "Format PROMPT, expand directory DIR and return them as a pair."
  (let ((edir (file-name-as-directory (expand-file-name dir)))
        (ddir (file-name-as-directory (expand-file-name default-directory))))
    (cons
     (if (string= ddir edir)
         (concat prompt ": ")
       (format "%s (%s): " prompt (consult--abbreviate-directory dir)))
     edir)))
```

the change I propose then -- which achieves the desired result,  
though likely not in the desired manner -- is to check if the  
passed dir arg is `string=` for the project root.

I had considered checking if the `root` path of the project  
exists in the abs path of DIR[1], but given the use of  
`{C-u M-x consult-ripgrep}`to choose a directory, I thought it  
inappropriate.  

patch:function:consult--directory-prompt-1:
```
(defun consult--directory-prompt-1 (prompt dir)
  "Format PROMPT, expand directory DIR and return them as a pair."
  (let ((edir (file-name-as-directory (expand-file-name dir)))
        (ddir (file-name-as-directory (expand-file-name default-directory)))
        (pdir (file-name-as-directory (expand-file-name (consult--project-root)))))
    (cons
     (cond
      ((string= ddir edir) (concat prompt ": "))
      ((string= edir pdir) (format "%s (%s %s): " prompt "Project" (consult--project-name pdir)))
      (t (format "%s (%s): " prompt (consult--abbreviate-directory dir))))
     edir)))

```
[1] e.g. `(string-match (consult--project-root) edir)`

To use this change, I have a temporary binding for an
approximation of 'project-consult-ripgrep` as follows:

``` emacs-lisp

          (defun rde-project-ripgrep ()
            (interactive)
            (consult-ripgrep (consult--project-root)))

           (define-key project-prefix-map (kbd "M-g") 'rde-consult-ripgrep)
           (add-to-list 'project-switch-commands '(rde-consult-ripgrep "ripgrep") t)

```

then the bindings are exposed to `project-map`, so `{C-x p M-g}`  
and `{C-x p p *my-project* RET M-g}` 

Off the top of my head, an example package defining `project`  
mappings ootb is magit --  

https://github.com/magit/magit/blob/1eb183e7672bf25fa77ea06d97b3d9c502a698ae/lisp/magit-extras.el#L142-L164
``` emacs-lisp
;;;###autoload
(defun magit-project-status ()
  "Run `magit-status' in the current project's root."
  (interactive)
  (magit-status-setup-buffer (project-root (project-current t))))

(defvar magit-bind-magit-project-status t
  "Whether to bind \"m\" to `magit-project-status' in `project-prefix-map'.
If so, then an entry is added to `project-switch-commands' as
well.  If you want to use another key, then you must set this
to nil before loading Magit to prevent \"m\" from being bound.")

(with-eval-after-load 'project
  ;; Only more recent versions of project.el have `project-prefix-map' and
  ;; `project-switch-commands', though project.el is available in Emacs 25.
  (when (and magit-bind-magit-project-status
             (boundp 'project-prefix-map)
             ;; Only modify if it hasn't already been modified.
             (equal project-switch-commands
                    (eval (car (get 'project-switch-commands 'standard-value))
                          t)))
    (define-key project-prefix-map "m" #'magit-project-status)
    (add-to-list 'project-switch-commands '(magit-project-status "Magit") t)))
```