### PR TITLE
Fix "Selecting deleted buffer" error which was appear when using conult-grep or consult-ripgrep in TRAMP.

### DIFF
--- a/consult.el
+++ b/consult.el
@@ -1641,7 +1641,7 @@ PROPS are optional properties passed to `make-process'."
                                    :connection-type pipe
                                    :name ,(car args)
                                    ;;; XXX tramp bug, the stderr buffer must be empty
-                                   :stderr ,stderr-buffer
+                                   :stderr ,(get-buffer-create " *consult-async-stderr*")
                                    :noquery t
                                    :command ,args
                                    :filter ,proc-filter


### PR DESCRIPTION
Hello.

Ther is an error with text `Selecting deleted buffer` when using consult-grep or consult-ripgrep in TRAMP.

Here is full trace:
```
Debugger entered--Lisp error: (error "Selecting deleted buffer")
  #f(compiled-function (proc msg) #<bytecode -0x610fca2564832cf>)(#<process rg> "finished\n")
  apply(#f(compiled-function (proc msg) #<bytecode -0x610fca2564832cf>) (#<process rg> "finished\n"))
  #f(advice-wrapper :after #f(compiled-function (_ event) #<bytecode 0x8670c4ba6ee75a4>) #f(compiled-function (proc msg) #<bytecode -0x610fca2564832cf>))(#<process rg> "finished\n")
  read-from-minibuffer("Ripgrep (Project macs): " "#" (keymap (10 . minibuffer-complete-and-exit) (13 . minibuffer-complete-and-exit) keymap (menu-bar keymap (minibuf "Minibuf" keymap (tab menu-item "Complete" minibuffer-complete :help "Complete as far as possible") (space menu-item "Complete Word" minibuffer-complete-word :help "Complete at most one word") (63 menu-item "List Completions" minibuffer-completion-help :help "Display all possible completions") "Minibuf")) (27 keymap (118 . switch-to-completions)) (prior . switch-to-completions) (63 . minibuffer-completion-help) (32 . minibuffer-complete-word) (9 . minibuffer-complete) keymap (3 keymap (9 . marginalia-cycle) (15 . embark-export)) (menu-bar keymap (minibuf "Minibuf" keymap (previous menu-item "Previous History Item" previous-history-element :help "Put previous minibuffer history element in the min...") (next menu-item "Next History Item" next-history-element :help "Put next minibuffer history element in the minibuf...") (isearch-backward menu-item "Isearch History Backward" isearch-backward :help "Incrementally search minibuffer history backward") (isearch-forward menu-item "Isearch History Forward" isearch-forward :help "Incrementally search minibuffer history forward") (return menu-item "Enter" exit-minibuffer :key-sequence "\15" :help "Terminate input and exit minibuffer") (quit menu-item "Quit" abort-recursive-edit :help "Abort input and exit minibuffer") "Minibuf")) (10 . exit-minibuffer) (13 . exit-minibuffer) (7 . abort-recursive-edit) (C-tab . file-cache-minibuffer-complete) (9 . self-insert-command) (XF86Back . previous-history-element) (up . previous-line-or-history-element) (prior . previous-history-element) (XF86Forward . next-history-element) (down . next-line-or-history-element) (next . next-history-element) (27 keymap (121 . yank-pop) (60 . minibuffer-beginning-of-buffer) (114 . previous-matching-history-element) (115 . next-matching-history-element) (112 . previous-history-element) (110 . next-history-element))) nil consult--grep-history nil nil)
  #f(compiled-function (prompt collection &optional predicate require-match initial-input hist def inherit-input-method) "Default method for reading from the minibuffer with completion.\nSee `completing-read' for the meaning of the arguments." #<bytecode -0xfcd960105960da9>)("Ripgrep (Project macs): " #f(compiled-function (str pred action) #<bytecode -0xf64117cb27378b8>) nil t "#" consult--grep-history nil nil)
  apply((#f(compiled-function (prompt collection &optional predicate require-match initial-input hist def inherit-input-method) "Default method for reading from the minibuffer with completion.\nSee `completing-read' for the meaning of the arguments." #<bytecode -0xfcd960105960da9>) "Ripgrep (Project macs): " #f(compiled-function (str pred action) #<bytecode -0xf64117cb27378b8>) nil t "#" consult--grep-history nil nil))
  vertico--advice(#f(compiled-function (prompt collection &optional predicate require-match initial-input hist def inherit-input-method) "Default method for reading from the minibuffer with completion.\nSee `completing-read' for the meaning of the arguments." #<bytecode -0xfcd960105960da9>) "Ripgrep (Project macs): " #f(compiled-function (str pred action) #<bytecode -0xf64117cb27378b8>) nil t "#" consult--grep-history nil nil)
  apply(vertico--advice #f(compiled-function (prompt collection &optional predicate require-match initial-input hist def inherit-input-method) "Default method for reading from the minibuffer with completion.\nSee `completing-read' for the meaning of the arguments." #<bytecode -0xfcd960105960da9>) ("Ripgrep (Project macs): " #f(compiled-function (str pred action) #<bytecode -0xf64117cb27378b8>) nil t "#" consult--grep-history nil nil))
  completing-read-default("Ripgrep (Project macs): " #f(compiled-function (str pred action) #<bytecode -0xf64117cb27378b8>) nil t "#" consult--grep-history nil nil)
  completing-read("Ripgrep (Project macs): " #f(compiled-function (str pred action) #<bytecode -0xf64117cb27378b8>) nil t "#" consult--grep-history nil nil)
  #f(compiled-function () #<bytecode -0xf39b7fe3737fca7>)()
  consult--with-preview-1([134217774] #f(compiled-function (cand restore) #<bytecode 0x4d94a958afa0bc4>) #f(compiled-function (input cand) #<bytecode 0x9ab47d9a3d27229>) #f(compiled-function (&rest args2) #<bytecode -0x16114b7fd2a2abd>) #f(compiled-function () #<bytecode -0xf39b7fe3737fca7>))
  consult--read-1(#f(compiled-function (action) #<bytecode 0x772d589f7367237>) :prompt "Ripgrep (Project macs): " :lookup consult--lookup-member :state #f(compiled-function (cand restore) #<bytecode 0x4d94a958afa0bc4>) :initial "#" :add-history #("#Recent" 1 7 (font-lock-face magit-section-heading fontified t magit-section #<magit-section "@{upstream}.." [unpushed status] 199-[214-]1926> keymap (keymap (remap keymap (magit-visit-thing . magit-diff-dwim))))) :require-match t :category consult-grep :group consult--grep-group :history (:input consult--grep-history) :sort nil :prompt "Select: " :preview-key [134217774] :sort t :lookup #f(compiled-function (input cands x) #<bytecode 0x4aa4fc234c19aef>))
  apply(consult--read-1 #f(compiled-function (action) #<bytecode 0x772d589f7367237>) (:prompt "Ripgrep (Project macs): " :lookup consult--lookup-member :state #f(compiled-function (cand restore) #<bytecode 0x4d94a958afa0bc4>) :initial "#" :add-history #("#Recent" 1 7 (font-lock-face magit-section-heading fontified t magit-section #<magit-section "@{upstream}.." [unpushed status] 199-[214-]1926> keymap (keymap (remap keymap (magit-visit-thing . magit-diff-dwim))))) :require-match t :category consult-grep :group consult--grep-group :history (:input consult--grep-history) :sort nil :prompt "Select: " :preview-key [134217774] :sort t :lookup #f(compiled-function (input cands x) #<bytecode 0x4aa4fc234c19aef>)))
  consult--read(#f(compiled-function (action) #<bytecode 0x772d589f7367237>) :prompt "Ripgrep (Project macs): " :lookup consult--lookup-member :state #f(compiled-function (cand restore) #<bytecode 0x4d94a958afa0bc4>) :initial "#" :add-history #("#Recent" 1 7 (font-lock-face magit-section-heading fontified t magit-section #<magit-section "@{upstream}.." [unpushed status] 199-[214-]1926> keymap (keymap (remap keymap (magit-visit-thing . magit-diff-dwim))))) :require-match t :category consult-grep :group consult--grep-group :history (:input consult--grep-history) :sort nil)
  consult--grep("Ripgrep" consult--ripgrep-builder nil nil)
  consult-ripgrep(nil)
  funcall-interactively(consult-ripgrep nil)
  call-interactively(consult-ripgrep nil nil)
  command-execute(consult-ripgrep)
```

This PR tries to address this issue, but note that my elisp skills are limited.