### PR TITLE
Improve focus-lines speed using multi-line overlays

### DIFF
--- a/consult.el
+++ b/consult.el
@@ -3045,7 +3045,6 @@ INITIAL is the initial input."
 		   (finish nil)
 		   (max (point-max)))
 	      (unless (eq matches t)	;input arrived
-		(message "%s %d lines" (if not "Excluded" "Included") (length matches))
 		(while matches
 		  (pcase-let* ((`(,ind ,beg ,end) (car matches))
 			       (new-block (> (- ind old-ind) 1)))

--- a/consult.el
+++ b/consult.el
@@ -2995,8 +2995,7 @@ INITIAL is the initial input."
 
 (defsubst consult--extract-line-ind (matches)
   "Extract and sort (line beg end) from MATCHES."
-  (sort (mapcar (apply-partially #'get-text-property 0 'line) matches)
-	(lambda (a b) (< (car a) (car b)))))
+  (mapcar (apply-partially #'get-text-property 0 'line) matches))
 
 (defun consult--focus-lines-state (filter)
   "State function for `consult-focus-lines' with FILTER function."
@@ -3021,7 +3020,8 @@ INITIAL is the initial input."
 		  (if (eq beg end) (char-to-string ?\n) ; "\n" reuses string! 
 		    (buffer-substring-no-properties beg end)))
 	    (add-text-properties 0 1 `(line (,(cl-incf i) ,beg ,end)) line)
-	    (push line lines)))))
+	    (push line lines))
+	  (setq lines (nreverse lines)))))
     (cl-labels ((add-inv-ov (beg end)
 			    (push (consult--overlay beg end 'invisible t)
 				  overlays)))

--- a/consult.el
+++ b/consult.el
@@ -3064,12 +3064,12 @@ INITIAL is the initial input."
 	  (mapc #'delete-overlay overlays)
 	  (goto-char point-orig))
 	 ((equal input "")
-	  (setq consult--focus-lines-overlays (seq-copy overlays)) ;;XXX loses old overlays
 	  (consult-focus-lines 'show)
 	  (goto-char point-orig))
 	 (t
 	  ;; Sucessfully terminated -> Remember invisible overlays
-	  (consult--focus-lines-overlays (seq-copy overlays))
+	  (setq consult--focus-lines-overlays  ; FIXME: overlap possible
+		(nconc consult--focus-lines-overlays overlays))
 	  (if-let ((invisible-p point-orig) ;move point past invisible
 		   (ovs (overlays-at point-orig))
 		   (ov (seq-find (lambda (ov) (overlay-get ov 'invisible)) ovs)))


### PR DESCRIPTION
This improves the speed of `consult-focus-lines` by:

- Storing line number + line begin & end as text properties on the line candidates to be matched.
- Extracting this information from the text properties in resulting matches.
- Using the matched line data to merge contiguous blocks of lines, substantially reducing the number of overlays needed.  Overlays are not pre-allocated, but instead deleted and re-created on each new input.

To ensure every line has the `'line` text property added, blank lines are collected as `\n`.  I tested this on a file with >250,000 lines (`/usr/share/dict/words`).  The current version does not make it to the prompt after several minutes of waiting.  This is likely due to the pre-allocation of one overlay per line.  This version works reasonably well on such a long file.  With fewer overlays, it also modestly improves navigation speed in the buffer, likely due to reducing the need to skip over the many invisible overlays.

In addition, it:

- Correctly exits the current search on interruption
- Provides a message update during the search with the number of included/excluded lines.
- Moves point past the enclosing invisible overlay when finished [1]. Fixes #493.

[1] Note that emacs normally moves point out of invisible regions after commands, but not at/near the beginning of buffer (where it moves to `(point-min)`, which may be hidden).