### PR TITLE
Wrap all heavy computations in while-no-input

### DIFF
--- a/consult.el
+++ b/consult.el
@@ -3026,31 +3026,29 @@ INITIAL is the initial input."
         (mapc #'delete-overlay overlays)
         (setq last-input input overlays nil)
         (unless (string-match-p "\\`!? ?\\'" input) ;; empty input.
-          (let* ((not (string-prefix-p "! " input))
-                 (stripped (string-remove-prefix "! " input))
-                 ;; Heavy computation is interruptible if *not* committing!
-                 (matches (if restore
-                              (funcall filter stripped lines)
-                            (while-no-input (funcall filter stripped lines))))
-                 (old-ind 0)
-                 (block-beg pt-min)
-                 (block-end pt-min))
-            (unless (eq matches t)      ;; input arrived
-              (while old-ind
-                (let ((match (pop matches)) (ind nil) (beg pt-max) (end pt-max) prop)
-                  (when match
-                    (setq prop (get-text-property 0 'consult--focus-line match)
-                          ind (car prop)
-                          beg (cdr prop)
-                          ;; NOTE: Check for empty lines, see above!
-                          end (+ 1 beg (if (equal match "\n") 0 (length match)))))
-                  (unless (eq ind (1+ old-ind))
-                    (let ((a (if not block-beg block-end))
-                          (b (if not block-end beg)))
-                      (when (/= a b)
-                        (push (consult--overlay a b 'invisible t) overlays)))
-                    (setq block-beg beg))
-                  (setq block-end end old-ind ind)))))))
+	  (while-no-input
+	    (let* ((inhibit-quit restore)
+		   (not (string-prefix-p "! " input))
+		   (stripped (string-remove-prefix "! " input))
+		   (matches (funcall filter stripped lines))
+		   (old-ind 0)
+		   (block-beg pt-min)
+		   (block-end pt-min))
+	      (while old-ind
+		(let ((match (pop matches)) (ind nil) (beg pt-max) (end pt-max) prop)
+		  (when match
+		    (setq prop (get-text-property 0 'consult--focus-line match)
+			  ind (car prop)
+			  beg (cdr prop)
+			  ;; NOTE: Check for empty lines, see above!
+			  end (+ 1 beg (if (equal match "\n") 0 (length match)))))
+		  (unless (eq ind (1+ old-ind))
+		    (let ((a (if not block-beg block-end))
+			  (b (if not block-end beg)))
+		      (when (/= a b)
+			(push (consult--overlay a b 'invisible t) overlays)))
+		    (setq block-beg beg))
+		  (setq block-end end old-ind ind)))))))
       (when restore
         (cond
          ((not input)


### PR DESCRIPTION
Currently `while-no-input` wraps the filtering portion of focus-lines.  But in fact the computation and creation of overlays is the heavier computational load, especially when there are many matches.  This PR wraps both filtering and overlay computation in `while-no-input`, disabling this if `restore` is set.  Since the first (least general) part of the input matches the most lines and is therefore (by far) the slowest, this _really_ helps with apparent performance for large files.  With this fix, searching with several letter long inputs in `/usr/dict/words` (236k lines) happens ~instantaneously.