### PR TITLE
Fix for EXWM buffers stealing focus during preview

### DIFF
--- a/consult.el
+++ b/consult.el
@@ -4032,7 +4032,11 @@ Report progress and return a list of the results"
 (defun consult--buffer-action (buffer &optional norecord)
   "Switch to BUFFER via `consult--buffer-display' function.
 If NORECORD is non-nil, do not record the buffer switch in the buffer list."
-  (funcall consult--buffer-display buffer norecord))
+  (prog1
+      (funcall consult--buffer-display buffer norecord)
+    ;; Stop EXWM buffers from hijacking focus. See https://github.com/minad/consult/issues/178.
+    (when-let ((mini (active-minibuffer-window)))
+      (select-window (active-minibuffer-window)))))
 
 (consult--define-state buffer)
 


### PR DESCRIPTION
Good news! I found a way to fix the EXWM focus stealing issue during buffer previews.I've tested this out pretty heavily over the last hour or so and it works reliably for me. 

For context, see:
- https://github.com/minad/consult/issues/178
- https://github.com/minad/consult/issues/204
- https://github.com/minad/consult/issues/239
- https://github.com/ch11ng/exwm/issues/813

---
 
As far as the implementation: I considered wrapping this in a conditional to only trigger for EXWM buffers, but I didn't see the point in adding complexity since this is effectively a no-op for other buffer types. I didn't notice a performance hit either, but I'm running on a pretty fast system. I'm happy to make changes if you have feedback.

I realize this is an EXWM bug and not a Consult issue, but unfortunately for the couple years EXWM has received very little love so I'm not holding my breath for a fix on their side. On the bright side, this workaround is so trivial it doesn't seem too egregious to add to Consult.

@minad How do you feel about this?