### PR TITLE
Delay mode hooks when previewing files

### DIFF
--- a/consult.el
+++ b/consult.el
@@ -1124,7 +1124,8 @@ MARKER is the cursor position."
                       (prog1 nil
                         (message "File `%s' (%s) is too large for preview"
                                  name (file-size-human-readable size)))
-                 (cl-letf* (((default-value 'find-file-hook)
+                 (cl-letf* (((default-value 'delay-mode-hooks) t)
+                            ((default-value 'find-file-hook)
                              (seq-remove (lambda (x)
                                            (memq x consult-preview-excluded-hooks))
                                          (default-value 'find-file-hook)))


### PR DESCRIPTION
Fixes #515.

This will skip running all mode hooks, including say the activation of a language server or starting a Flyspell process. If desired, we could run some of the `delayed-mode-hooks` based on a whitelist or blacklist. But I don't think this is actually necessary.