### PR TITLE
Remove a problematic single quote in docstring

### DIFF
--- a/consult-register.el
+++ b/consult-register.el
@@ -40,7 +40,7 @@
     (?f . "File")
     (?w . "Window"))
   "Register type names.
-Each element of the list must have the form '(char . name).")
+Each element of the list must have the form (char . name).")
 
 (cl-defun consult-register--format-value (val)
   "Format generic register VAL as string."


### PR DESCRIPTION
The byte-compiler recently got more fussy about quotes.