### PR TITLE
Add consult-org-contacts function

### DIFF
--- a/consult-org.el
+++ b/consult-org.el
@@ -112,6 +112,17 @@ buffer are offered."
      :lookup #'consult--lookup-candidate)))
 
 ;;;###autoload
+(defun consult-org-contacts (&optional match)
+  "Jump to an Org contacts heading using files defined in `org-contacts-files'.
+
+By default, all contacts file entries are offered. MATCH is as in
+`org-map-entries' and can be used to refine this."
+  (interactive)
+  (unless org-contacts-files
+    (user-error "No contacts files defined."))
+  (consult-org-heading match org-contacts-files))
+
+;;;###autoload
 (defun consult-org-agenda (&optional match)
   "Jump to an Org agenda heading.
 

--- a/consult-org.el
+++ b/consult-org.el
@@ -116,8 +116,12 @@ buffer are offered."
   "Jump to an Org contacts heading using files defined in `org-contacts-files'.
 
 By default, all contacts file entries are offered. MATCH is as in
-`org-map-entries' and can be used to refine this."
+`org-map-entries' and can be used to refine this. This function requires that
+the library `org-contacts.el' be installed and the variable `org-contacts-files'
+be set."
   (interactive)
+  (unless (locate-library "org-contacts")
+    (user-error "org-contacts must be installed to use this function."))
   (unless org-contacts-files
     (user-error "No contacts files defined."))
   (consult-org-heading match org-contacts-files))


### PR DESCRIPTION
This is a small extension to your wonderful consult-org package.

This update adds a function `consult-org-contacts` that will search contacts for those who use the org-contacts.el library. Similar to org-agenda, org-contacts is a list of files used to store contact information with each contact being an org heading. This means we can search the contacts similar to the function `consult-org-agenda`.

The function checks to see if the library `org-contacts.el` is in the `load-path` and if the variable `org-contacts-files` is set, otherwise it throws an error. It does not check if the library is actually loaded, however, as-like me-others may have the library loading deferred.