### PR TITLE
Fix for previewing on not current window

### DIFF
--- a/consult.el
+++ b/consult.el
@@ -469,7 +469,7 @@ called from the corresponding command. Note that the options depend on
 the private `consult--read' API and should not be considered as stable
 as the public API.")
 
-(defvar consult--buffer-display #'switch-to-buffer
+(defvar consult--buffer-display #'display-buffer
   "Buffer display function.")
 
 (defvar consult--completion-candidate-hook


### PR DESCRIPTION
`consult--jump-preview` could not work with the feature that manages `display-buffer-function` like [e2wm.el](https://github.com/kiwanami/emacs-window-manager).
That's because `consult--buffer-action` don't have a consideration for the case that `current-buffer` won't be switched.

So, I tried to fix this trouble and it looks to work well with this fix.