### PR TITLE
Move yanked string to top of kill ring after yanking

### DIFF
--- a/consult.el
+++ b/consult.el
@@ -3569,6 +3569,8 @@ version supports preview of the selected string."
     (push-mark)
     (insert-for-yank string)
     (setq this-command 'yank)
+    (setq kill-ring (delete string kill-ring))
+    (kill-new string)
     (when (consp arg)
       ;; Swap point and mark like in `yank'.
       (goto-char (prog1 (mark t)


### PR DESCRIPTION
Firstly, thank you so much for this amazing project.

Please review this PR. I bind `M-y` to `consult-yank-pop`, and this change made my life a lot easier because previously when I needed to yank the same content again and again from the kill ring, I had to pick it from the kill ring far away from the top, not to mention that the content would eventually be removed from the kill ring altogether.