### PR TITLE
consult-yank-(pop/replace) follows yank-kill-from-rotate

### DIFF
--- a/consult.el
+++ b/consult.el
@@ -3541,7 +3541,10 @@ If no MODES are specified, use currently active major and minor modes."
   (consult--lookup-member
    (consult--read
     (consult--remove-dups
-     (or kill-ring (user-error "Kill ring is empty")))
+     (or (append
+          kill-ring-yank-pointer
+          (butlast kill-ring (length kill-ring-yank-pointer)))
+         (user-error "Kill ring is empty")))
     :prompt "Yank from kill-ring: "
     :history t ;; disable history
     :sort nil
@@ -3569,6 +3572,11 @@ version supports preview of the selected string."
     (push-mark)
     (insert-for-yank string)
     (setq this-command 'yank)
+    (when yank-from-kill-ring-rotate
+      (let ((pos (seq-position kill-ring string)))
+        (if pos
+            (setq kill-ring-yank-pointer (nthcdr pos kill-ring))
+          (kill-new string))))
     (when (consp arg)
       ;; Swap point and mark like in `yank'.
       (goto-char (prog1 (mark t)


### PR DESCRIPTION
If `yank-from-kill-ring-rotate` is set to t, `consult-yank-(pop/replace)` will put the last yanked value at the top of the candidates by rotating the kill-ring

If the kill-ring is `'(1 2 3 4)` and 3 was the last yanked value, kill-ring-yank-pointer is `'(3 4)`, by appending `(butlast '(1 2 3 4) (length '(3 4)))` to `'(3 4)` we have a new kill-ring that is `'(3 4 1 2)`

This fixes #668 and provides a better solution than #681 (this solution has the default of modifying kill-ring in place)

@minad Sorry for the delay, had some issues and couldn't work on this until now. Thanks for your patience :-)