### PR TITLE
consult-isearch-history: use cursor-in-echo-area

### DIFF
--- a/consult.el
+++ b/consult.el
@@ -4111,8 +4111,8 @@ This replaces the current search string if Isearch is active, and
 starts a new Isearch session otherwise."
   (interactive)
   (consult--forbid-minibuffer)
-  (let* ((isearch-message-function 'ignore) ;; Avoid flicker in echo area
-         (inhibit-redisplay t)              ;; Avoid flicker in mode line
+  (let* ((isearch-message-function #'ignore)
+         (cursor-in-echo-area t) ;; Avoid cursor flickering
          (candidates (consult--isearch-history-candidates)))
     (unless isearch-mode (isearch-mode t))
     (with-isearch-suspended


### PR DESCRIPTION
I wasn't aware of `cursor-in-echo-area` when I wrote this function, but it's a much less drastic measure than `inhibit-redisplay` (which makes Emacs temporarily unresponsive to the user).

I'm a bit puzzled by the comments explaining the source of flickering. I don't see any flickering in the mode line on my Emacs 29 with pgtk, even if I disable both let-bindings. The only flickering I can see is in the cursor.

(Also, for the record, when you drop support for Emacs 28 you could rely on `minibuffer-lazy-highlight-setup`. But it's not clear it will simplify `consult-isearch-history` too much.)