### PR TITLE
consult-org-*: show inherited tags

### DIFF
--- a/consult-org.el
+++ b/consult-org.el
@@ -67,12 +67,13 @@ MATCH, SCOPE and SKIP are as in `org-map-entries'."
        (unless (eq buffer (buffer-name))
          (setq buffer (buffer-name)
                org-outline-path-cache nil))
-       (pcase-let ((`(_ ,level ,todo ,prio ,_hl ,tags) (org-heading-components))
+       (pcase-let ((`(_ ,level ,todo ,prio ,_hl) (org-heading-components))
+                   (tags (org-get-tags))
                    (cand (org-format-outline-path
                           (org-get-outline-path 'with-self 'use-cache)
                           most-positive-fixnum)))
          (when tags
-           (setq tags (concat " " tags))
+           (setq tags (concat " :" (string-join tags ":") ":"))
            (put-text-property 1 (length tags) 'face 'org-tag tags))
          (setq cand (if prefix
                         (concat buffer " " cand tags (consult--tofu-encode (point)))


### PR DESCRIPTION
This patch changes `consult-org--headings` to get tags with `org-get-tags` instead of `org-heading-components`.  This means inherited tags will now be shown (assuming `org-use-tag-inheritance` is non-nil).

Things I've checked:
  - `org-get-tags` uses an internal org cache and the cache seems to be enabled on all my org buffers,
  - I've run `consult-org-agenda` and `consult-org-headings` on a variety of my buffers and they showed inherited tags,
  - I've set `org-use-tag-inheritance` to nil and checked that local tags are still shown, but inherited tags are not.

Disclaimer: While I am a software developer, I am definitely not an elisp developer and I had to lookup the docs for every function I've used.  I don't know if there's a better way to do this.

Closes #765 