### PR TITLE
consult-man: fix regexp type

### DIFF
--- a/consult.el
+++ b/consult.el
@@ -4970,10 +4970,10 @@ details regarding the asynchronous search."
 (defun consult--man-builder (input)
   "Build command line from INPUT."
   (pcase-let* ((`(,arg . ,opts) (consult--command-split input))
-               (`(,re . ,hl) (funcall consult--regexp-compiler arg 'basic t)))
+               (`(,re . ,hl) (funcall consult--regexp-compiler arg 'extended t)))
     (when re
       (cons (append (consult--build-args consult-man-args)
-                    (list (consult--join-regexps re 'basic))
+                    (list (consult--join-regexps re 'extended))
                     opts)
             hl))))
 


### PR DESCRIPTION
`man -k` is equivalent to `apropos`.  According to the manpage `apropos (1)` defaults to interpret the patterns as extended regular expressions.

        POSIXLY_CORRECT
              If $POSIXLY_CORRECT is set, even to a null value, the default apropos search will be as an extended
              regex (-r).  Nowadays, this is the default behaviour anyway.