### PR TITLE
Add user option `consult-kmacro-runner`.

### DIFF
--- a/consult-kmacro.el
+++ b/consult-kmacro.el
@@ -30,6 +30,14 @@
 
 (defvar consult-kmacro--history nil)
 
+(defcustom consult-kmacro-runner nil
+  "A function used to run the keyboard macro chosen by `consult-kmacro'.
+
+This function receives two arguments: the macro (as a function)
+and the prefix argument of `consult-kmacro'."
+  :group 'consult
+  :type '(choice function (const nil)))
+
 (defun consult-kmacro--candidates ()
   "Return alist of kmacros and indices."
   (thread-last
@@ -66,7 +74,10 @@
   "Run a chosen keyboard macro.
 
 With prefix ARG, run the macro that many times.
-Macros containing mouse clicks are omitted."
+Macros containing mouse clicks are omitted.
+
+When `consult-kmacro-runner' is non-nil, it is used
+to run the chosen keyboard macro."
   (interactive "p")
   (let ((km (consult--read
              (or (consult-kmacro--candidates)
@@ -82,6 +93,7 @@ Macros containing mouse clicks are omitted."
              :lookup #'consult--lookup-candidate)))
     (unless km (user-error "No kmacro selected"))
     (funcall
+     (or consult-kmacro-runner #'funcall)
      ;; Kmacros are lambdas (oclosures) on Emacs 29
      (if (eval-when-compile (> emacs-major-version 28))
          km


### PR DESCRIPTION
Hi, Minad.

I am trying out the package Meow, which can play back kmacros at multiple locations using its ["Beacon" state](https://github.com/meow-edit/meow/blob/master/TUTORIAL.org#beacon). Meow uses its own commands for running the last defined kmacro at the "beacons", so it doesn't automatically work with `consult-kmacro`.

This PR adds a way to pass the kmacro selected by `consult-kmacro` to another function that would run the kmacro. While I intend to use this with Meow, it feels reasonable to assume that other packages, maybe Multiple Cursors, would also benefit.

Would you be open to adding something like this?

The function receives two arguments: the chosen keyboard macro (as a function) and the prefix argument of `consult-kmacro`.