### PR TITLE
consult-register--describe: Accept buffer as a buffer object

### DIFF
--- a/consult-register.el
+++ b/consult-register.el
@@ -90,7 +90,7 @@ Each element of the list must have the form (char . name).")
 
 (cl-defmethod consult-register--describe ((val (head buffer)))
   "Describe buffer register VAL."
-  (list (propertize (cdr val) 'face 'consult-buffer)
+  (list (propertize (format "%s" (cdr val)) 'face 'consult-buffer)
         'consult--type ?f 'multi-category `(buffer . ,(cdr val))))
 
 (cl-defmethod consult-register--describe ((val (head file-query)))


### PR DESCRIPTION
* consult-register.el (consult-register--describe): Accept buffer as a buffer object.

`(cdr val)` can be a string or buffer object, since `cl-defmethod register-val-jump-to ((val cons) delete)` in register.el calls:
```
((eq (car val) 'buffer)
    (switch-to-buffer (cdr val)))
```
and `cl-defmethod register-val-describe ((val cons) verbose)` calls:
```
((eq (car val) 'buffer)
    (princ "the buffer ")
    (prin1 (cdr val))
    (princ "."))
```