### PR TITLE
consult--find-file-temporarily-1 : improve binary detection heuristic

### DIFF
--- a/consult.el
+++ b/consult.el
@@ -1270,7 +1270,7 @@ ORIG is the original function, HOOKS the arguments."
           (with-current-buffer buf
             (if (save-excursion
                   (goto-char (point-min))
-                  (search-forward "\0" nil 'noerror))
+                  (search-forward "\0" 40 'noerror))
                 (progn
                   (kill-buffer buf)
                   (format "Binary file `%s' not previewed literally" name))


### PR DESCRIPTION
Hi Daniel,

To decide whether to preview a file, various consult commands use `consult--find-file-temporarily-1`. This function contains a heuristic to decide whether the file to be previewed is binary.

The heuristic is the following : if the null character ("\0") is present at all in the file, then the file is deemed binary and the preview is cancelled.

This heuristic is too violent, and presents too many false positives. I met such a false positive when trying `consult-ripgrep` on a directory that contained multiple info files (the directory info of the latest emacs release, to be specific, that contains some very large info files). Those files are very much text, with some rare null characters here and there. It would be nice to be able to preview those when using `consult-ripgrep`.

In fact, for real binary files, like `/usr/bin/bash`, those null characters are going to be there from the first bytes. It is therefore possible to limit the search to the first bytes (I chose 40 arbitrarily), which will remove false positives without increasing false negatives, improving the accuracy of the heuristic. Another benefit is that the search is now constant in the size of the file.

With this patch, I am now able to preview correctly text files that were previously incorrectly deemed binary. Feel free to use this.

Best,

Aymeric