### PR TITLE
Allow custom sort function. Add one based on path commonality for xref

### DIFF
--- a/README.org
+++ b/README.org
@@ -980,7 +980,7 @@ Useful options are:
 - =:default= set the default value
 - =:history= set the history variable symbol
 - =:add-history= add items to the future history, for example symbol at point
-- =:sort= enable or disable sorting
+- =:sort= enable (t) or disable (nil) sorting, or specify a custom =display-sort-function=
 - =:group= set to nil to disable candidate grouping and titles.
 - =:inherit-input-method= set to non-nil to inherit the input method.
 

--- a/consult-xref.el
+++ b/consult-xref.el
@@ -102,7 +102,7 @@ FETCHER and ALIST arguments."
             :prompt "Go to xref: "
             :history 'consult-xref--history
             :require-match t
-            :sort nil
+            :sort #'consult-sort-path-commonality
             :category 'consult-xref
             :group #'consult--prefix-group
             :state


### PR DESCRIPTION
When working with large repos, both tag-based xref and git can generate loads of matches that aren't at all relevant. Add a display-sort-function, `consult-sort-path-commonality` that looks at how many path elements are in common between each candidate and the last buffer with a filename, something we can do pretty fast.

Pass `:sort` configs that are not `t` as display/cycle sort functions to allow consult-customization.

Use the new function for xref where it's a good match without any downsides IMHO.

#### Algorithm/speed considerations

Other than code simplicity, another factor considered is that this can run on tens of thousands of files, and repeatedly for git-grep [async]. Many clever things won't work well at scale, e.g.  longest contiguous substring or making paths absolute. Instead, we rely on the regex engine and count the matches on any of the reference components without even extracting substrings. E.g. this is 5x faster than even a similarly naive path-components-hash-count. It works well enough in practice for focusing xref or grep in a large project to the closest related files, to the point that xref even when tag-based becomes magically good as opposed to usually needing refinement.  [I could swear the old tags had something similar, but I can't find this anymore].

I expect this sort will be used for both relative and absolute path producing commands, so the code makes no assumptions about how relative the paths are and relative to what.

As for speed, it sorts 65K path matches from a intentionally vague search -- for commonality with a "current path" 15 directories deep -- in 0.4 seconds on my Macbook. This is IMHO fast enough.

Why it's not the default for git-grep and locate:  in async commands that do take a while, sorting can be slightly disconcerting as new paths can pop at the top of the tree when the finder gets close to current. While those are often the most interesting results, it might not be to everyone's taste. locate is better than git-grep in this regard just because it's faster. Anyway, changing the defaults or customizing is simple enough. I do use it for both myself.

One reason the sort is stable, by commonality only, as opposed to "then by alpha", is to minimize the jumping when we're not actually finding any results with common path elements. Easy enough to presort with a secondary criterion if needed.

I hereby and hereafter assign the copyright to this chunk of code to the FSF.