### PR TITLE
consult--directory-prompt: Use filename syntax table

### DIFF
--- a/consult.el
+++ b/consult.el
@@ -807,9 +807,11 @@ asked for the directories or files to search via
                               ;; mostly deprecated, but still in use. Packages
                               ;; should instead use the completion metadata.
                               (minibuffer-completing-file-name t))
-                          (completing-read-multiple "Directories or files: "
-                                                    #'completion-file-name-table
-                                                    nil t def 'consult--path-history def)))
+                          (consult--minibuffer-with-setup-hook
+                              (lambda () (set-syntax-table minibuffer-local-filename-syntax))
+                            (completing-read-multiple "Directories or files: "
+                                                      #'completion-file-name-table
+                                                      nil t def 'consult--path-history def))))
                  ((and `(,p) (guard (file-directory-p p))) p)
                  (ps (setq paths (mapcar (lambda (p)
                                            (file-relative-name (expand-file-name p)))


### PR DESCRIPTION
This PR adds a minibuffer setup hook to `consult--directory-prompt` which sets up the filename syntax table, like in `read-file-name` here: https://github.com/emacs-mirror/emacs/blob/6abea4d98d1d964c68a78cb9b5321071da851654/lisp/minibuffer.el#L3518-L3537

I'm not sure if we would want some of the other setup in the `read-file-name` hook (like setting the `M-n` default to the selected buffer file), but setting the syntax table fixes functions like `backward-kill-sexp` not working right when running for example `consult-grep` with a prefix arg to select the dir to run in (it would kill past `/` delimiters).