### PR TITLE
consult-register: Set register-command-info (Emacs 30)

### DIFF
--- a/consult-register.el
+++ b/consult-register.el
@@ -233,6 +233,15 @@ for the meaning of prefix ARG."
      (unless (string-search "access aborted" (error-message-string err))
        (insert-register reg (not arg))))))
 
+;; When `register-read-with-preview' is called, and `register-use-preview' is
+;; set to nil or `never', it checks whether the command calling it just wants
+;; to jump to a register, and skips an additional confirmation in that case.
+;; This restores the register behaviour of earlier versions of Emacs.
+(when (>= emacs-major-version 30)
+  (cl-defmethod register-command-info ((_command (eql consult-register-load)))
+    "Register command info for `consult-register-load'."
+    (register-command-info #'jump-to-register)))
+
 (defun consult-register--action (action-list)
   "Read register key and execute action from ACTION-LIST.
 


### PR DESCRIPTION
Emacs recently changed how register jumping/loading is handled. The variable `register-use-preview` may be used to adjust that behaviour; it's read and acted upon by (e.g.) `register-read-with-preview`. That function (which we call inside of `consult-register-load`) checks which command called it and gets some information about that via the `register-command-info` defmethod. If (say) the command indicates that it just wants to jump to some register, an additional confirmation is skipped when `register-use-preview` is set to an appropriate value.

Thus, to completely restore how Emacs used to handle register, we need `consult-register-load` to signal that all it does it jump to the register.

---

N.b.: I didn't change the changelog yet, as I don't know if this qualifies as something that should be in there.