### PR TITLE
Use (cons 'buffer . buffer-object) as multi-category for candidates

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -2,6 +2,11 @@
 #+author: Daniel Mendler
 #+language: en
 
+* Development
+
+- Bugfix: Handle buffer renaming during minibuffer completion gracefully, by
+  attaching the actual buffer objects to the completion candidate strings.
+
 * Version 1.4 (2024-03-08)
 
 - Bugfix: File preview: Ensure that binary files are not previewed partially.

--- a/README.org
+++ b/README.org
@@ -675,7 +675,7 @@ ones.
             (consult--buffer-action (current-buffer))))
         :items
         (lambda ()
-          (consult--buffer-query :mode 'org-mode :as #'buffer-name))))
+          (consult--buffer-query :mode 'org-mode :as #'consult--buffer-pair))))
 
 (add-to-list 'consult-buffer-sources 'org-source 'append)
 #+end_src


### PR DESCRIPTION
This fixes the problem where buffers are renamed during completion. Renaming can happen during buffer name uniquify or due to EXWM renaming. See the issues #978 and #979.

Consult buffer preview magically continues to work since `get-buffer` accepts both string and buffer arguments. I haven't tested Embark yet.