### PR TITLE
Add `consult-org-agenda-multi`

### DIFF
--- a/consult.el
+++ b/consult.el
@@ -2933,6 +2933,21 @@ Optional source fields:
       (setq selected `(,(car selected) :match t ,@(cdr selected))))
     selected))
 
+;;;; Source generators for consult--multi
+
+(defun consult--file-relative-source (name filenames dir)
+  "Generate file candatate source NAME; FILENAMES are presented relative to DIR."
+  `(:name ,name
+    :category file
+    :narrow ?f
+    :history file-name-history
+    :state ,#'consult--file-state
+    :items
+    ,(mapcar (lambda (f)
+               (propertize (file-relative-name f dir)
+                           'multi-category (cons 'file f)))
+             filenames)))
+
 ;;;; Customization macro
 
 (defun consult--customize-put (cmds prop form)


### PR DESCRIPTION
Adds a command `consult-org-agenda-multi`, a command to jump to an agenda file or an agenda heading, using `consult--multi`.

To achieve this, the following changes have been made:

- `consult-org--annotate` has been rewritten. It now supports adding the filename as an annotation, which is necessary for `consult-org-agenda-multi` since it can't group the headings by file. Moreover, the annotations are padded to form neatly aligned columns. The annotations to be added can be specified - this is used to preserve the original behavior for `consult-org-heading`.

- To simplify the above, some changes have been made to the way `consult-org--headings` stores the heading attributes in the `consult-org--heading` text property of each heading. It now adds the correct face to the todo keyword, and the priority is now a propertized priority cookie string.

- A new state function `consult-org--heading-state` has been introduced. It wraps `consult--jump-state`, passing the marker from the `org-marker` text property of each heading to those functions. For consistency, `consult-org-heading` has also been made to use this state function.

- Two new sources, `consult--file-relative-source` and `consult-org--heading-source`, have been introduced for use in `consult--multi`. They are implemented as functions that generate sources, so that they can be reused with different parameters in other functions.


I haven't signed the FSF papers yet; let me know if you'd be willing to merge this, and then I'll look into it.