### PR TITLE
Add file preview to `consult-find`

### DIFF
--- a/consult.el
+++ b/consult.el
@@ -4978,6 +4978,7 @@ INITIAL is initial input."
      :file-handler t) ;; allow tramp
    :prompt prompt
    :sort nil
+   :state (consult--file-preview)
    :require-match t
    :initial (consult--async-split-initial initial)
    :add-history (consult--async-split-thingatpt 'filename)


### PR DESCRIPTION
This is such that triggering the `:preview-key` of a `consult-find` will preview the file, as it does for `consult-recent-file`