### PR TITLE
add consult-rg-dir for rg search under directory, with symbol under cursor

### DIFF
--- a/consult.el
+++ b/consult.el
@@ -4960,6 +4960,12 @@ See `consult-grep' for details."
   (interactive "P")
   (consult--grep "Ripgrep" #'consult--ripgrep-make-builder dir initial))
 
+;;;###autoload
+(defun consult-rg-dir ()
+  "Search with `rg` for files in prompted DIR with symbol under cursor."
+  (interactive)
+  (consult-ripgrep (read-directory-name "rg directory: ") (thing-at-point 'symbol)))
+
 ;;;;; Command: consult-find
 
 (defun consult--find (prompt builder initial)


### PR DESCRIPTION
Hi, I found that I often need to search under a directory, with the symbol under cursor. It's a very common situation. But after some digging, I didn't find a function to do the work. So I add a new function `consult-rg-dir` to do the job:

```
;;;###autoload
(defun consult-rg-dir ()
  "Search with `rg` for files in prompted DIR with symbol under cursor."
  (interactive)
  (consult-ripgrep (read-directory-name "rg directory: ") (thing-at-point 'symbol)))
```

It will prompt for directory, which can be chosen by user, and then do `rg` search using symbol under the cursor.

Hope It will be helpful.