### PR TITLE
consult-kmacro: Silence byte-compiler

### DIFF
--- a/consult-kmacro.el
+++ b/consult-kmacro.el
@@ -25,6 +25,8 @@
 
 ;;; Code:
 
+(eval-when-compile
+  (require 'subr-x))
 (require 'consult)
 (require 'kmacro)
 


### PR DESCRIPTION
Without this patch, byte-compile throws an error because `thread-last` is not found. `consult.el` already contains the same form for `require`-ing `subr-x`, but the macro won't be available for `consult-kmacro.el` at compile time, unless it is loaded again like this?