### PR TITLE
consult-project-grep added, fixed consult--with-project

### DIFF
--- a/README.org
+++ b/README.org
@@ -240,6 +240,7 @@ their descriptions.
 #+cindex: locate
 
 #+findex: consult-grep
+#+findex: consult-project-grep
 #+findex: consult-ripgrep
 #+findex: consult-git-grep
 #+findex: consult-find
@@ -262,6 +263,7 @@ their descriptions.
   [[#project-support][project directory]] if a project is found. Otherwise the =default-directory= is
   searched. If =consult-grep= is invoked with prefix argument =C-u M-s g=, you can
   specify one or more comma-separated files and directories manually.
+- =consult-project-grep=: Variant of =consult-grep=, prompting for a project if not in one.
 - =consult-find=, =consult-fd=, =consult-locate=: Find file by matching the path
   against a regexp. Like for =consult-grep=, either the project root or the
   current directory is the root directory for the search. The input string is
@@ -779,6 +781,7 @@ configuration examples.
          ("C-x t b" . consult-buffer-other-tab)    ;; orig. switch-to-buffer-other-tab
          ("C-x r b" . consult-bookmark)            ;; orig. bookmark-jump
          ("C-x p b" . consult-project-buffer)      ;; orig. project-switch-to-buffer
+         ("C-x p g" . consult-project-grep)	     ;; orig. project-find-regexp
          ;; Custom M-# bindings for fast register access
          ("M-#" . consult-register-load)
          ("M-'" . consult-register-store)          ;; orig. abbrev-prefix-mark (unrelated)

--- a/consult.el
+++ b/consult.el
@@ -4691,14 +4691,14 @@ configuration of the virtual buffer sources."
   ;; project.  But who does that? Working on the first level on project A
   ;; and on the second level on project B and on the third level on project C?
   ;; You mustn't be afraid to dream a little bigger, darling.
-  `(let ((consult-project-function
-          (let ((root (or (consult--project-root t) (user-error "No project found")))
-                (depth (recursion-depth))
-                (orig consult-project-function))
-            (lambda (may-prompt)
-              (if (= depth (recursion-depth))
-                  root
-                (funcall orig may-prompt))))))
+  `(let* ((root (or (consult--project-root t) (user-error "No project found")))
+          (depth (recursion-depth))
+          (orig consult-project-function)
+          (consult-project-function
+           (lambda (may-prompt)
+             (if (= depth (recursion-depth))
+                 root
+               (funcall orig may-prompt)))))
      ,@body))
 
 ;;;###autoload
@@ -4709,6 +4709,16 @@ outside a project.  See `consult-buffer' for more details."
   (interactive)
   (consult--with-project
    (consult-buffer consult-project-buffer-sources)))
+
+;;;###autoload
+(defun consult-project-grep ()
+  "Variant of `consult-grep`, meant to be a replacement for `project-find-regexp`.
+The command prompts you for a project directory if it is invoked from
+outside a project."
+  (interactive)
+  (consult--with-project
+   (consult--grep "Grep" #'consult--grep-make-builder nil nil))))
+
 
 ;;;###autoload
 (defun consult-buffer-other-window ()


### PR DESCRIPTION
Summary: Used to using the project bindings from anywhere, wanted to use consult-grep in the same manner as project-find-regexp, prompting for a project root if not in one.

This PR consists of two changes, one adding consult-project-grep and one fixing the consult--with-project macro.

Issue with consult--with-project macro:

The macro errors when `consult-project-function` is needed in the body. Steps to reproduce:

1. Have consult installed.
2. Have an available project.
3. `emacs -q`
4. Evaluate `(require 'package)`, `(package-initialize)`, `(require 'consult)`
5. Open a scratch buffer
6. Paste the following function:
`(defun consult-project-grep ()
  (interactive)
  (consult--with-project
   (consult--grep "Grep" #'consult--grep-make-builder nil nil)))
`
7. Evaluate the buffer.
8. Execute `consult-project-grep` and select a valid project.
9. You should encounter the following error: `if: Symbol’s value as variable is void: depth`.

If `depth` is provided, it will fail on `root`. 

The provided fix allows `consult-project-grep` to be called. This can be tested by including the modified `consult--with-project` in the scratch buffer an evaluating it again.

I've checked the code, `consult--with-project` is used in one place, for `consult-project-buffer`. I've run this function after applying the change, it all still works as expected.

Annoyance: `C-x p p` -> `g Find regexp` does not call `consult-project-grep`, leading to inconsistent behavior. Unsure how to tackle this.

Future plans: I´d like to add `consul-project-find` to act in the same way, prompting for a project root if note in one already, this goes beyond my current capabilities, sadly.


This is my first PR for an Emacs package (or PR outside of work in general), if I've missed something, please let me know. I have not yet signed the copyright over to the FSF yet, since I wanted to see first if this PR is wanted.