### PR TITLE
consult--async-split: do not insert initial split char if the minibuffer already starts with it

### DIFF
--- a/consult.el
+++ b/consult.el
@@ -2393,7 +2393,8 @@ configured by `consult-async-split-style'."
          (when-let ((initial (plist-get style :initial)))
            (save-excursion
              (goto-char (minibuffer-prompt-end))
-             (insert-before-markers initial)))
+             (unless (string-prefix-p initial (minibuffer-contents))
+               (insert-before-markers initial))))
          (funcall sink 'setup))
         ((pred stringp)
          (pcase-let ((`(,input ,_ . ,highlights)


### PR DESCRIPTION
When running vertico-repeat-previous, vertico will clear the minibuffer and then insert the text that was saved in history (e.g. "#some-text").

Later, when consult--async-split tries to insert the split char, the restored session ends up with "##some-text" as input -- which does not search for anything.

This commit fixes the issue by checking the minibuffer contents before inserting the initial split char.