### PR TITLE
Use the base-size returned by completion-all-completions correctly

### DIFF
--- a/consult.el
+++ b/consult.el
@@ -3340,13 +3340,12 @@ value for `completion-in-region-function'."
              (or (not (consp (ignore-errors (nthcdr threshold all))))
                  (and completion-cycling completion-all-sorted-completions)))
         (completion--in-region start end collection predicate)
-      (let* ((limit (car (completion-boundaries initial collection predicate "")))
-             (this-command #'consult-completion-in-region)
+      (let* ((this-command #'consult-completion-in-region)
              (completion
               (cond
                ((atom all) nil)
                ((and (consp all) (atom (cdr all)))
-                (concat (substring initial 0 limit) (car all)))
+                (concat (substring initial 0 (cdr all)) (car all)))
                (t
                 (consult--local-let ((enable-recursive-minibuffers t))
                   ;; Evaluate completion table in the original buffer.


### PR DESCRIPTION
Using completion-boundaries here is incorrect and doesn't work in practice for completion tables with non-trivial boundaries.  The correct thing to do is to use the base-size returned as the cdr of the last element of completion-all-completions.