### PR TITLE
consult-man: use 'manual-program rather than assuming "man"

### DIFF
--- a/consult.el
+++ b/consult.el
@@ -317,7 +317,7 @@ Can be either a string, or a list of strings or expressions."
   :type '(choice string (repeat (choice string sexp))))
 
 (defcustom consult-man-args
-  "man -k"
+  (concat manual-program " -k")
   "Command line arguments for man, see `consult-man'.
 The dynamically computed arguments are appended.
 Can be either a string, or a list of strings or expressions."


### PR DESCRIPTION
From the commit:

```
For the reasons listed on the original swiper issue[1], on macOS
`gman` is preferred to `man`. Emacs actually provides the
`manual-program` variable to customize that, so observe the
abstraction in consult-man as well.

[1]: https://github.com/abo-abo/swiper/issues/2836
```