### PR TITLE
Mark the consult-buffer command with :category 'consult-buffer

### DIFF
--- a/consult.el
+++ b/consult.el
@@ -4976,6 +4976,7 @@ configuration of the virtual buffer sources."
                                   (confirm-nonexistent-file-or-buffer)
                                   :prompt "Switch to: "
                                   :history 'consult--buffer-history
+                                  :category 'consult-buffer
                                   :sort nil)))
     ;; For non-matching candidates, fall back to buffer creation.
     (unless (plist-get (cdr selected) :match)


### PR DESCRIPTION
So the end-user can costumize styles (e.g. in vertico-multiform).