### PR TITLE
consult-theme: gracefully handle cases where custom-available-themes contains non-themes

### DIFF
--- a/consult.el
+++ b/consult.el
@@ -4631,7 +4631,10 @@ The command supports previewing the currently selected theme."
     (when theme
       (if (custom-theme-p theme)
           (enable-theme theme)
-        (load-theme theme :no-confirm)))))
+        (load-theme theme :no-confirm :no-enable)
+        (if (custom-theme-p theme)
+            (enable-theme theme)
+          (message "%s is not really a theme" theme))))))
 
 ;;;;; Command: consult-buffer
 


### PR DESCRIPTION
Some theme packages (e.g. solarized and spacemacs) break the convention that custom-available-themes assumes.  For example, spacemacs-theme.el defines spacemacs-dark and spacemacs-light, but it doesn't define a theme named spacemacs.  custom-available-themes assumes that a file named spacemacs-theme.el will define a theme named spacemacs, but it won't know for sure until it loads that file.  As a result, custom-available-themes will include an entry for 'spacemacs, but attempting to (load-theme 'spacemacs) results in an error.  When consult-theme encounters this error, it breaks and stops previewing themes entirely.

Unfortunately we aren't really in a position to do better than custom-available-themes when we encounter 'spacemacs in the list of available themes.  We can't filter it out without first loading the theme file, and we only do that after the user has already selected it!  We can at least ensure that we don't break when the user scrolls past one of these entries by being a bit defensive.

Instead of just calling load-theme and allowing it to implicitly enable, we'll split loading and enabling into two separate steps so we can check if its a real theme before we try to enable it.