### PR TITLE
better handling of `imenu-default-goto-function`

### DIFF
--- a/consult-imenu.el
+++ b/consult-imenu.el
@@ -72,8 +72,10 @@ ARGS are the arguments to the special item function."
     (`(,pos ,fn . ,args)
      (setq pos `(,pos ,#'consult-imenu--switch-buffer ,(current-buffer)
                       ,fn ,@args))))
-  (if (or (consp pos)
-          (eq imenu-default-goto-function #'imenu-default-goto-function))
+  (if (and (consp pos)
+           (stringp (car pos))
+           (or (markerp (cdr pos) (integerp (cdr pos))))
+           (eq imenu-default-goto-function #'imenu-default-goto-function))
       pos
     (list pos #'consult-imenu--switch-buffer (current-buffer)
           imenu-default-goto-function)))


### PR DESCRIPTION
this patch add explicit type checking for `imenu-default-goto-function`.
its signature is like 
```elisp
(defun imenu-default-goto-function (_name position &rest _rest) 
  "Move to the given position.

NAME is ignored.  POSITION is where to move.  REST is also ignored.
The ignored args just make this function have the same interface as a
function placed in a special index-item."
...)
```
I'm not sure what NAME actually is, seems to be a string?

- motivation
 a package I used has customize `imenu-default-goto-function`,
and its parameter is `(line-number . line-pos)`, happens to match the original
condition. Other customization of imenu-default-goto-function could probably
do this too, so I write a PR here.

I'm not sure above is correct, and there isn't much resource about formats of a imenu
entry as well. Maybe this is a disscussion more than an actual PR.
Please feel free to correct me if I figured anying wrong!