### PR TITLE
Fix quoting of backslash in regex

### DIFF
--- a/consult.el
+++ b/consult.el
@@ -674,7 +674,7 @@ Turn ARG into a list, and for each element either:
         (setq opts (substring str (1- (match-end 0)))
               str (substring str 0 (match-beginning 0))))
       ;; Replace backslash-escaped dashes
-      (setq str (replace-regexp-in-string "\\(\\`\\| \\)\\-" "\\1-" str))
+      (setq str (replace-regexp-in-string "\\(\\`\\| \\)\\\\-" "\\1-" str))
       ;; Options end with double dash
       (when (string-match "\\(\\`\\| \\)--\\(?: \\|\\'\\)" opts)
         (setq str (concat str " " (substring opts (match-end 0)))


### PR DESCRIPTION
This came up https://codeberg.org/rahguzar/consult-hoogle/issues/32.

Before this change:
```emacs-lisp
(consult--command-split "a \\-> b")
```
results in `"a \\-> b"`. After this change it results in `a -> b` which I think is the intended behavior.

I basically converted the current regexp to sexp form using `xr` and saw that it isn't matching on the backslash. The change is the result of micro-expansion of `(rx (group (or bos " ")) "\\-")`