### PR TITLE
Initialize buffers on final selection via `consult-after-final-jump-hook`

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -2,6 +2,13 @@
 #+author: Daniel Mendler
 #+language: en
 
+* Development
+
+- Add =consult-after-final-jump-hook=, which is executed when a candidate is
+  finally selected. The convenience function =consult-run-suppressed-hooks=
+  can be added to this hook to ensure that suppressed =find-file-hook=
+  members (e.g., =recentf=, =vc-refresh-state=) are executed upon arrival.
+
 * Version 3.4 (2026-03-09)
 
 - Bugfixes.

--- a/consult.el
+++ b/consult.el
@@ -170,12 +170,33 @@ nil shows all `custom-available-themes'."
   :type '(repeat (choice symbol regexp)))
 
 (defcustom consult-after-jump-hook (list #'recenter)
-  "Function called after jumping to a location.
+  "Functions called after jumping to a location.
+
+This hook is executed after every jump, including both preview
+movements during completion and the final jump after selection.
 
 Commonly used functions for this hook are `recenter' and
 `reposition-window'.  You may want to add a function which pulses the
-current line, e.g., `pulse-momentary-highlight-one-line'.  The hook
-called during preview and for the jump after selection."
+current line, e.g., `pulse-momentary-highlight-one-line'.
+
+See also `consult-after-final-jump-hook' for a hook that is executed
+only once after the final selection."
+  :type 'hook)
+
+(defcustom consult-after-final-jump-hook nil
+  "Functions called after the final jump to a location.
+
+This hook is called only once when the user officially selects a
+candidate, in contrast to `consult-after-jump-hook' which also
+fires during every preview movement.
+
+One can add functions such as `recentf-track-opened-file' or
+`vc-refresh-state' to this hook to ensure that standard Emacs hooks
+are executed upon selection.  For convenience, the utility function
+`consult-run-suppressed-hooks' is provided to automatically execute
+all hooks that were blocked during preview.  Adding this function to
+`consult-after-final-jump-hook' ensures the buffer is fully
+initialized, as when normally opening a file."
   :type 'hook)
 
 (defcustom consult-line-start-from-top nil
@@ -1566,10 +1587,20 @@ See `isearch-open-necessary-overlays' and `isearch-open-overlay-temporary'."
               (consult--buffer-action buf 'norecord))
             t))))
 
+(defun consult-run-suppressed-hooks ()
+  "Run `find-file-hook' functions that were blocked during preview.
+This function is intended to be added to `consult-after-final-jump-hook'."
+  (save-excursion
+    (dolist (hook find-file-hook)
+      (unless (consult--preview-allowed-p hook)
+        (when (and (symbolp hook) (fboundp hook))
+          (funcall hook))))))
+
 (defun consult--jump (pos)
   "Jump to POS.
 First push current position to mark ring, then move to new
-position and run `consult-after-jump-hook'."
+position and run `consult-after-jump-hook' and
+`consult-after-final-jump-hook'."
   (when pos
     ;; Extract marker from list with with overlay positions, see `consult--line-match'
     (when (consp pos) (setq pos (car pos)))
@@ -1586,7 +1617,8 @@ position and run `consult-after-jump-hook'."
         (widen)
         (goto-char pos))
       (consult--invisible-open-permanently)
-      (run-hooks 'consult-after-jump-hook)))
+      (run-hooks 'consult-after-jump-hook)
+      (run-hooks 'consult-after-final-jump-hook)))
   nil)
 
 (defun consult--jump-preview ()


### PR DESCRIPTION
This PR fixes an issue where buffers opened through Consult's preview mechanism remain partially initialized after they are finally selected. This prevents core Emacs features like `recentf` from correctly tracking files opened via commands like `consult-ripgrep`.

### The Technical Problem: "Half-Initialized" Buffers

1.  **Selective Hook Suppression**: To maintain high performance during live previews, Consult suppresses most `find-file-hook` members that aren't explicitly allowed in `consult-preview-allowed-hooks`.
2.  **Buffer Reuse**: When a user confirms a selection that was being previewed, Consult switches to the already-open preview buffer instead of opening a fresh one.
3.  **Missing Initialization**: Because the buffer is already active, standard Emacs hooks like `find-file-hook` do not re-run upon selection. This means side effects like updating the `recentf` history, refreshing VCS state, or running full mode-specific logic are never triggered for that file.

This creates an inconsistency where `consult-find` (which typically opens a new buffer) initializes correctly, but `consult-ripgrep` or `consult-line` (which often reuse preview buffers) do not.

### The Proposed Solution

This PR introduces a canonical mechanism to handle the transition from a "previewed" state to a "selected" state.

1.  **`consult-after-final-jump-hook`**: A new hook that fires exactly once when a candidate is finally selected in `consult--jump`. This is distinct from `consult-after-jump-hook`, which runs on every preview movement.
2.  **`consult-run-suppressed-hooks`**: A utility function provided for users who want to fully initialize their buffers upon selection. It identifies and executes only the `find-file-hook` members that were blocked during the preview phase.

### Usage Example

To opt-in to full buffer initialization, users can add this to their configuration:

```elisp
(add-hook 'consult-after-final-jump-hook #'consult-run-suppressed-hooks)
```

Alternatively, if a user only wants specific features like `recentf`, they can add them individually:

```elisp
(add-hook 'consult-after-final-jump-hook #'recentf-track-opened-file)
```

### Implementation Details

- Added `consult-after-final-jump-hook` (defcustom, hook).
- Added `consult-run-suppressed-hooks` utility function.
- Updated `consult--jump` to trigger the new hook.
- Updated docstrings for `consult-after-jump-hook` and `consult-after-final-jump-hook`.