### PR TITLE
Add consult-org-tag

### DIFF
--- a/README.org
+++ b/README.org
@@ -343,6 +343,7 @@ their descriptions.
 
 #+findex: consult-org-heading
 #+findex: consult-org-agenda
+#+findex: consult-org-tag
 - =consult-org-heading=: Variant of =consult-imenu= or =consult-outline= for Org
   buffers. The headline and its ancestors headlines are separated by slashes.
   Supports narrowing by heading level, priority and TODO keyword, as well as live
@@ -350,6 +351,7 @@ their descriptions.
 - =consult-org-agenda=: Jump to an Org agenda heading. Supports narrowing by
   heading level, priority and TODO keyword, as well as live preview and
   recursive editing.
+- =consult-org-tag=: Add or remove tags for a heading. Selecting a tag that a heading already has will remove it from the heading. Works in Org agenda buffers.
 ** Help
 :properties:
 :description: Searching through help

--- a/consult-org.el
+++ b/consult-org.el
@@ -26,6 +26,7 @@
 
 (require 'consult)
 (require 'org)
+(require 'org-agenda)
 
 (defvar consult-org--history nil)
 
@@ -139,6 +140,77 @@ By default, all agenda entries are offered.  MATCH is as in
   (unless org-agenda-files
     (user-error "No agenda files"))
   (consult-org-heading match 'agenda))
+
+(defun consult-org-tag ()
+  "Add or remove tags for an Org heading."
+  (interactive)
+  (let ((current-tags nil)
+        (new-tags nil))
+    (save-excursion
+      ;; There are 3 cases:
+      ;; - In Org Agenda, marked none: save current tags
+      ;; - In Org Agenda, marked multiple (or one): don't
+      ;; - In normal Org mode: save current tags
+      (if (eq major-mode 'org-agenda-mode)
+          (unless org-agenda-bulk-marked-entries
+            (let ((hdmarker (or (org-get-at-bol 'org-hd-marker)
+                                (org-agenda-error))))
+              (with-current-buffer (marker-buffer hdmarker)
+                (goto-char hdmarker)
+                (setq current-tags (org-get-tags nil t)))))
+        (unless (org-at-heading-p)
+          (org-back-to-heading t))
+        (setq current-tags (org-get-tags nil t)))
+
+      (let* ((org-last-tags-completion-table ; for `org-tags-completion-function'
+              (append (and (or org-complete-tags-always-offer-all-agenda-tags
+                               (eq major-mode 'org-agenda-mode))
+                           (org-global-tags-completion-table
+                            (org-agenda-files)))
+                      (or org-current-tag-alist
+                          ;; `org-get-buffer-tags' errors for me in Org Agenda
+                          ;; about org-element-cache not being active. Since
+                          ;; this is just for completion (convenience) if it
+                          ;; errors just go on without it.
+                          (ignore-errors (org-get-buffer-tags)))))
+             (selected (consult--read
+                        (lambda (str _pred _action)
+                          (delete-dups
+                           (all-completions str #'org-tags-completion-function)))
+                        :prompt (if current-tags
+                                    (format "Tags (%s): " (mapconcat #'identity current-tags ", "))
+                                  "Tags: ")
+                        :history 'org-tags-history)))
+
+        (setq new-tags
+              (cond ((member selected current-tags) (remove selected current-tags))
+                    ((equal selected "") current-tags)
+                    (t (append current-tags (list selected)))))
+
+        ;; The same 3 cases:
+        ;; - In Org Agenda, marked none: find the entry at point and set
+        ;;   tags for it
+        ;; - In Org Agenda, marked some: set tags for each of them, although for
+        ;;   these we need to check their original tags here instead of having
+        ;;   that done at the top
+        ;; - In normal Org mode: set tags for the current entry
+        (if (eq major-mode 'org-agenda-mode)
+            (if (null org-agenda-bulk-marked-entries)
+                (let ((hdmarker (or (org-get-at-bol 'org-hd-marker)
+                                    (org-agenda-error))))
+                  (with-current-buffer (marker-buffer hdmarker)
+                    (goto-char hdmarker)
+                    (org-set-tags new-tags)))
+              (dolist (m org-agenda-bulk-marked-entries)
+                (with-current-buffer (marker-buffer m)
+                  (save-excursion
+                    (goto-char m)
+                    (org-set-tags
+                     (seq-uniq
+                      (append (org-get-tags nil t) new-tags)))))))
+          (org-set-tags new-tags)
+          (unless (member selected new-tags)
+            (consult--minibuffer-message "Tag %S has been removed." selected)))))))
 
 (provide 'consult-org)
 ;;; consult-org.el ends here


### PR DESCRIPTION
This removes a tag if the chosen tag is already on the heading. This also has support for adding or removing tags from the agenda.

[螢幕錄製_20260503_001552.webm](https://github.com/user-attachments/assets/a7ec58a2-7170-40bf-adca-1945ec15e99b)

There are some minor differences from Counsel, most notably this requires at least Org>=9.0 since I'm using org-current-tag-alist directly without adding fallbacks like Counsel does. This variable was added in 2016 (Org commit 4743d43dd8) and shipped in 9.0. Counsel predated that, but this port doesn't, so I don't think that's necessary.

I used consult--read since it appears no function in this project other than consult--read itself uses completing-read directly.

---

This is more or less a port of `counsel-org-tag`. License-wise since both Consult and Counsel are FSF-assigned (part of GNU Emacs) this should be fine.

I have assigned copyright to the FSF before (for my PRs to yaml.el when it was added to GNU ELPA).